### PR TITLE
feat(admin): restore chat broadcast tools in app settings

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -34,6 +34,22 @@ export const httpV2 = axios.create({
   baseURL: import.meta.env.VITE_API_V2,
 });
 
+export const httpV2App = axios.create({
+  baseURL: import.meta.env.VITE_API_V2,
+});
+
+function getAppJwt(): string {
+  let appJwt = httpTokens.appJwt;
+  if (!appJwt && typeof window !== 'undefined' && window.useAppStore) {
+    const appToken = window.useAppStore.getState()?.currentApp?.appToken;
+    if (appToken) {
+      appJwt = appToken;
+      httpTokens.appJwt = appToken;
+    }
+  }
+  return appJwt || '';
+}
+
 const AUTH_WHITELIST: Array<string | RegExp> = [
   '/users/login-with-email',
   '/users/login',
@@ -100,6 +116,14 @@ function attachAuthInterceptors(client: AxiosInstance) {
 
 attachAuthInterceptors(http);
 attachAuthInterceptors(httpV2);
+
+httpV2App.interceptors.request.use((config) => {
+  config.headers = config.headers || {};
+  if (!(config.headers as any).Authorization) {
+    (config.headers as any).Authorization = getAppJwt();
+  }
+  return config;
+}, null);
 
 export const refreshToken = async () => {
   try {
@@ -526,6 +550,33 @@ export function deleteDefaultRooms(appId: string, chatJid: string) {
       chatJid,
     },
   });
+}
+
+export function httpBroadcastChatsV2(
+  payload: {
+    text: string;
+    allRooms?: boolean;
+    chatNames?: string[];
+    chatIds?: string[];
+    metadata?: any;
+    dryRun?: boolean;
+  },
+  opts?: { appToken?: string }
+) {
+  const cfg = opts?.appToken
+    ? { headers: { Authorization: opts.appToken } }
+    : undefined;
+  return httpV2App.post('/chats/broadcast', payload, cfg);
+}
+
+export function httpGetBroadcastChatsJobV2(
+  jobId: string,
+  opts?: { appToken?: string }
+) {
+  const cfg = opts?.appToken
+    ? { headers: { Authorization: opts.appToken } }
+    : undefined;
+  return httpV2App.get(`/chats/broadcast/${jobId}`, cfg);
 }
 
 export const sendHSFormData = async (

--- a/src/pages/AppSettings/AppSettings.tsx
+++ b/src/pages/AppSettings/AppSettings.tsx
@@ -782,6 +782,7 @@ export default function AppSettings() {
               defaultChatRooms={defaultChatRooms}
               setDefaultChatRooms={setDefaultChatRooms}
               appId={appId as string}
+              appToken={app?.appToken || ''}
             />
           </TabPanel>
 

--- a/src/pages/AppSettings/Chats.tsx
+++ b/src/pages/AppSettings/Chats.tsx
@@ -1,11 +1,17 @@
 import { Checkbox, Dialog, DialogPanel, Field, Label } from '@headlessui/react';
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { IconAdd } from '../../components/Icons/IconAdd';
 import { IconCheckbox } from '../../components/Icons/IconCheckbox';
 import { ModelAppDefaulRooom } from '../../models';
 import { IconClose } from '../../components/Icons/IconClose';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { createAppChat, deleteDefaultRooms, getDefaultRooms } from '../../http';
+import {
+  createAppChat,
+  deleteDefaultRooms,
+  getDefaultRooms,
+  httpBroadcastChatsV2,
+  httpGetBroadcastChatsJobV2,
+} from '../../http';
 import { Loading } from '../../components/Loading';
 import { IconDelete } from '../../components/Icons/IconDelete';
 import { SubmitModal } from '../../components/modal/SubmitModal';
@@ -13,11 +19,12 @@ import { toast } from 'react-toastify';
 import { IconMinus } from '../../components/Icons/IconMinus';
 
 interface Props {
-  allowUsersToCreateRooms: boolean
-  setAllowUsersToCreateRooms: (value: boolean) => void
-  defaultChatRooms: Array<ModelAppDefaulRooom>,
-  setDefaultChatRooms: (value: Array<ModelAppDefaulRooom>) => void,
-  appId: string,
+  allowUsersToCreateRooms: boolean;
+  setAllowUsersToCreateRooms: (value: boolean) => void;
+  defaultChatRooms: Array<ModelAppDefaulRooom>;
+  setDefaultChatRooms: (value: Array<ModelAppDefaulRooom>) => void;
+  appId: string;
+  appToken: string;
 }
 
 interface Inputs {
@@ -25,23 +32,38 @@ interface Inputs {
   pinned: false;
 }
 
-export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, defaultChatRooms, setDefaultChatRooms, appId }: Props) {
+export function Chats({
+  allowUsersToCreateRooms,
+  setAllowUsersToCreateRooms,
+  defaultChatRooms,
+  setDefaultChatRooms,
+  appId,
+  appToken,
+}: Props) {
   const [showCreate, setShowCreate] = useState(false);
   const [allRowsSelected, setAllRowsSelected] = useState(false);
   const [showLoading, setShowLoading] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
 
+  const [broadcastText, setBroadcastText] = useState('');
+  const [broadcastMode, setBroadcastMode] = useState<'all' | 'selected'>('all');
+  const [broadcastSelected, setBroadcastSelected] = useState<
+    Record<string, boolean>
+  >({});
+  const [broadcastSending, setBroadcastSending] = useState(false);
+  const [broadcastJobId, setBroadcastJobId] = useState<string | null>(null);
+  const [broadcastJob, setBroadcastJob] = useState<any>(null);
+  const broadcastToastRef = useRef<{ completed: boolean; failed: boolean }>({
+    completed: false,
+    failed: false,
+  });
+
   const [rowsSelected, setRowsSelected] = useState(
     defaultChatRooms.map((_) => false)
   );
-
   const [someSelected, setSomeSelected] = useState(false);
 
-  const {
-    register,
-    handleSubmit,
-    reset
-  } = useForm<Inputs>();
+  const { register, handleSubmit, reset } = useForm<Inputs>();
 
   const setSelect = (select: boolean, index: number) => {
     const newRowsSelected = rowsSelected.concat([]);
@@ -63,7 +85,7 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
   };
 
   const renderActionsForSelected = () => {
-    let selectedIndexes = [];
+    const selectedIndexes: number[] = [];
 
     rowsSelected.forEach((el, index) => {
       if (el === true) {
@@ -72,7 +94,6 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
     });
 
     if (someSelected || allRowsSelected) {
-      // 
       return (
         <div className="shadow px-[16px] py-[12px] flex gap-[16px] items-center justify-center z-50 transform -translate-x-1/2 bg-white rounded-xl fixed left-[50%] bottom-[30px]">
           <button
@@ -86,9 +107,9 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
           </button>
         </div>
       );
-    } else {
-      return null;
     }
+
+    return null;
   };
 
   const onSelectAllRows = (selected: boolean) => {
@@ -103,7 +124,7 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
   };
 
   const getSelectedIndexes = () => {
-    let indexes: Array<number> = [];
+    const indexes: Array<number> = [];
 
     rowsSelected.forEach((el, index) => {
       if (el === true) {
@@ -115,40 +136,145 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
   };
 
   const onSubmit: SubmitHandler<Inputs> = async ({ chatTitle }) => {
-    setShowLoading(true)
+    setShowLoading(true);
     try {
-      await createAppChat(appId, chatTitle, true)
-      const { data } = await getDefaultRooms(appId)
-      setDefaultChatRooms(data)
-      setShowLoading(false)
-      reset()
-      setShowCreate(false)
-      toast.success('Chat created successfully')
-    } catch (error) {
-      setShowLoading(false)
-      toast.error('Failed to create chat')
+      await createAppChat(appId, chatTitle, true);
+      const { data } = await getDefaultRooms(appId);
+      setDefaultChatRooms(data);
+
+      // Refresh current app config so the chat area picks up new pinned rooms too.
+      const { actionGetConfig } = await import('../../actions');
+      await actionGetConfig();
+
+      setShowLoading(false);
+      reset();
+      setShowCreate(false);
+      toast.success('Chat created successfully');
+    } catch (error: any) {
+      setShowLoading(false);
+      console.error('Failed to create chat:', error);
+      toast.error(error?.response?.data?.error || 'Failed to create chat');
     }
-  }
+  };
 
   const onDelete = async () => {
-    let selectedRooms: Array<ModelAppDefaulRooom> = [];
+    const selectedRooms: Array<ModelAppDefaulRooom> = [];
     rowsSelected.forEach((el, index) => {
       if (el === true) {
-        let item = defaultChatRooms[index];
-        selectedRooms.push(item);
+        selectedRooms.push(defaultChatRooms[index]);
       }
     });
-    setShowLoading(true)
+    setShowLoading(true);
     for (const room of selectedRooms) {
-      await deleteDefaultRooms(appId, room.jid)
+      await deleteDefaultRooms(appId, room.jid);
     }
-    setSomeSelected(false)
-    setAllRowsSelected(false)
-    setShowLoading(false)
-    setShowDelete(false)
-    const { data } = await getDefaultRooms(appId)
-    setDefaultChatRooms(data)
+    setSomeSelected(false);
+    setAllRowsSelected(false);
+    setShowLoading(false);
+    setShowDelete(false);
+    const { data } = await getDefaultRooms(appId);
+    setDefaultChatRooms(data);
+  };
+
+  const pinnedRooms = defaultChatRooms || [];
+
+  const selectedPinnedRooms = useMemo(() => {
+    return pinnedRooms.filter((room) => broadcastSelected[room.jid]);
+  }, [pinnedRooms, broadcastSelected]);
+
+  function getChatNameFromJid(jid: string) {
+    const value = String(jid || '');
+    return value.split('@')[0] || value;
   }
+
+  useEffect(() => {
+    const next: Record<string, boolean> = {};
+    for (const room of pinnedRooms) {
+      next[room.jid] = Boolean(broadcastSelected[room.jid]);
+    }
+    setBroadcastSelected(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pinnedRooms.length]);
+
+  useEffect(() => {
+    if (!broadcastJobId) return;
+
+    let alive = true;
+    broadcastToastRef.current = { completed: false, failed: false };
+    let timerId: number | null = null;
+
+    const tick = async () => {
+      try {
+        const { data } = await httpGetBroadcastChatsJobV2(broadcastJobId, {
+          appToken,
+        });
+        if (!alive) return;
+        setBroadcastJob(data);
+        if (data?.state === 'completed' && !broadcastToastRef.current.completed) {
+          broadcastToastRef.current.completed = true;
+          const total = data?.result?.total ?? 0;
+          const sent = (data?.result?.results || []).filter(
+            (result: any) => result.status === 'sent'
+          ).length;
+          toast.success(`Broadcast completed: sent ${sent}/${total}`);
+          if (timerId) window.clearInterval(timerId);
+          alive = false;
+        }
+        if (data?.state === 'failed' && !broadcastToastRef.current.failed) {
+          broadcastToastRef.current.failed = true;
+          toast.error(`Broadcast failed: ${data?.error || 'unknown error'}`);
+          if (timerId) window.clearInterval(timerId);
+          alive = false;
+        }
+      } catch (_error: any) {
+        // Best-effort polling; avoid noisy UI errors while job is still starting.
+      }
+    };
+
+    tick();
+    timerId = window.setInterval(() => {
+      if (!alive) return;
+      tick();
+    }, 2000);
+
+    return () => {
+      alive = false;
+      if (timerId) window.clearInterval(timerId);
+    };
+  }, [appToken, broadcastJobId]);
+
+  const canSendBroadcast =
+    Boolean(broadcastText.trim()) &&
+    (broadcastMode === 'all' || selectedPinnedRooms.length > 0) &&
+    !broadcastSending;
+
+  const onSendBroadcast = async () => {
+    if (!canSendBroadcast) return;
+
+    setBroadcastSending(true);
+    setBroadcastJob(null);
+    setBroadcastJobId(null);
+    try {
+      const payload: any = {
+        text: broadcastText.trim(),
+        metadata: { source: 'admin_ui' },
+      };
+      if (broadcastMode === 'all') {
+        payload.allRooms = true;
+      } else {
+        payload.chatNames = selectedPinnedRooms.map((room) =>
+          getChatNameFromJid(room.jid)
+        );
+      }
+      const { data } = await httpBroadcastChatsV2(payload, { appToken });
+      setBroadcastJobId(String(data.jobId));
+      toast.info('Broadcast enqueued');
+    } catch (error: any) {
+      toast.error(error?.response?.data?.error || 'Failed to start broadcast');
+    } finally {
+      setBroadcastSending(false);
+    }
+  };
 
   return (
     <div className="overflow-hidden">
@@ -180,18 +306,20 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
         <div className="flex justify-between items-center mb-4">
           <div className="font-sans font-semibold text-base">List of chats</div>
           <div>
-            <button onClick={() => setShowCreate(true)} className="flex items-center justify-center md:w-[184px] h-[40px] w-[40px] bg-brand-500 rounded-xl text-white text-sm font-varela">
+            <button
+              onClick={() => setShowCreate(true)}
+              className="flex items-center justify-center md:w-[184px] h-[40px] w-[40px] bg-brand-500 rounded-xl text-white text-sm font-varela"
+            >
               <IconAdd color="white" className="md:mr-2" />
               <span className="hidden md:block">Add New Chat</span>
             </button>
           </div>
         </div>
         <div className="mx-2 overflow-auto">
-
           {!defaultChatRooms.length && (
             <div className="bg-[#F3F6FC] p-4 text-sm font-sans rounded-xl mb-4">
-              There are no chats yet, or you can add them by clicking the 'Add New Chat'
-              button
+              There are no chats yet, or you can add them by clicking the 'Add
+              New Chat' button
             </div>
           )}
 
@@ -203,13 +331,13 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
                     <Field className="flex items-center cursor-pointer">
                       <Checkbox
                         className="group size-4 rounded-[4px] border border-brand-500 data-[checked]:bg-brand-500 flex justify-center items-center"
-                        checked={(someSelected || allRowsSelected)}
+                        checked={someSelected || allRowsSelected}
                         onChange={onSelectAllRows}
                       >
                         {allRowsSelected && (
                           <IconCheckbox className="hidden group-data-[checked]:block" />
                         )}
-                        {(someSelected && !allRowsSelected) && (
+                        {someSelected && !allRowsSelected && (
                           <IconMinus className="hidden group-data-[checked]:block" />
                         )}
                       </Checkbox>
@@ -238,10 +366,10 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
                           </Checkbox>
                         </Field>
                       </td>
-                      <td className="px-4 py-[20px] font-sans font-normal text-sm  whitespace-nowrap">
+                      <td className="px-4 py-[20px] font-sans font-normal text-sm whitespace-nowrap">
                         {el.title}
                       </td>
-                      <td className="px-4 font-sans font-normal text-sm text-center  whitespace-nowrap">
+                      <td className="px-4 font-sans font-normal text-sm text-center whitespace-nowrap">
                         {el.creator}
                       </td>
                     </tr>
@@ -251,18 +379,205 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
               <tfoot></tfoot>
             </table>
           )}
-
-
         </div>
       </div>
+
+      <div className="mt-8">
+        <p className="font-semibold font-sans text-[16px] mb-2">
+          Broadcast Message
+        </p>
+        <p className="font-sans text-xs text-gray-500 mb-4">
+          Send an announcement to your chats. You can broadcast to all chats, or
+          choose a subset from your pinned rooms list.
+        </p>
+
+        <div className="p-4 border border-gray-200 rounded-xl">
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col md:flex-row gap-4 md:items-center">
+              <label className="inline-flex items-center gap-2 font-sans text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="broadcast-mode"
+                  checked={broadcastMode === 'all'}
+                  onChange={() => setBroadcastMode('all')}
+                />
+                All chats (recommended)
+              </label>
+              <label className="inline-flex items-center gap-2 font-sans text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="broadcast-mode"
+                  checked={broadcastMode === 'selected'}
+                  onChange={() => setBroadcastMode('selected')}
+                />
+                Selected pinned chats
+              </label>
+            </div>
+
+            {broadcastMode === 'selected' && (
+              <div className="bg-[#F3F6FC] p-4 rounded-xl">
+                {!pinnedRooms.length && (
+                  <div className="font-sans text-sm text-gray-700">
+                    No pinned rooms found. Add pinned chats above or switch to
+                    "All chats".
+                  </div>
+                )}
+                {!!pinnedRooms.length && (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                    {pinnedRooms.map((room) => (
+                      <label
+                        key={room.jid}
+                        className="flex items-center gap-2 font-sans text-sm cursor-pointer"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={Boolean(broadcastSelected[room.jid])}
+                          onChange={(e) => {
+                            setBroadcastSelected((prev) => ({
+                              ...prev,
+                              [room.jid]: e.target.checked,
+                            }));
+                          }}
+                        />
+                        <span className="truncate">{room.title}</span>
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            <textarea
+              value={broadcastText}
+              onChange={(e) => setBroadcastText(e.target.value)}
+              placeholder="Type your broadcast message..."
+              className="rounded-2xl bg-gray-100 py-3 px-6 w-full min-h-[96px] outline-none font-sans text-sm"
+              maxLength={4000}
+            />
+
+            <div className="flex flex-col md:flex-row gap-4 md:items-center md:justify-between">
+              <div className="font-sans text-xs text-gray-500">
+                {broadcastText.trim().length}/4000
+              </div>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => {
+                    setBroadcastText('');
+                    setBroadcastJobId(null);
+                    setBroadcastJob(null);
+                    setBroadcastSelected({});
+                    setBroadcastMode('all');
+                  }}
+                  className="px-4 py-2 rounded-xl border border-gray-300 text-gray-700 hover:bg-gray-50 font-varela text-sm"
+                  type="button"
+                >
+                  Clear
+                </button>
+                <button
+                  onClick={onSendBroadcast}
+                  disabled={!canSendBroadcast}
+                  className="px-4 py-2 rounded-xl bg-brand-500 text-white hover:bg-brand-darker font-varela text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                  type="button"
+                >
+                  {broadcastSending ? 'Sending...' : 'Send Broadcast'}
+                </button>
+              </div>
+            </div>
+
+            {broadcastJobId && (
+              <div className="mt-2 bg-[#FCFCFC] border border-gray-200 rounded-xl p-4">
+                <div className="font-sans text-sm font-semibold mb-1">
+                  Broadcast job
+                </div>
+                <div className="font-sans text-xs text-gray-600">
+                  Job ID: <span className="font-mono">{broadcastJobId}</span>
+                </div>
+                <div className="font-sans text-xs text-gray-600 mt-1">
+                  State:{' '}
+                  <span className="font-mono">
+                    {broadcastJob?.state || 'loading...'}
+                  </span>
+                </div>
+                {broadcastJob?.progress &&
+                  typeof broadcastJob.progress === 'object' && (
+                    <div className="font-sans text-xs text-gray-600 mt-1">
+                      Progress: {broadcastJob.progress.processed}/
+                      {broadcastJob.progress.total}
+                    </div>
+                  )}
+                {broadcastJob?.state === 'completed' && (
+                  <div className="font-sans text-xs text-gray-700 mt-2">
+                    Completed. Sent:{' '}
+                    {(broadcastJob?.result?.results || []).filter(
+                      (result: any) => result.status === 'sent'
+                    ).length}
+                    /{broadcastJob?.result?.total ?? 0}
+                  </div>
+                )}
+                {broadcastJob?.state === 'completed' &&
+                  Array.isArray(broadcastJob?.result?.results) && (
+                    <div className="mt-3">
+                      <div className="font-sans text-xs text-gray-600 mb-1">
+                        Details (first 20)
+                      </div>
+                      <div className="max-h-[180px] overflow-auto border border-gray-200 rounded-lg bg-white">
+                        <table className="w-full border-collapse">
+                          <thead>
+                            <tr className="bg-[#FCFCFC]">
+                              <th className="px-3 py-2 text-gray-500 font-normal font-inter text-xs text-left">
+                                Room
+                              </th>
+                              <th className="px-3 py-2 text-gray-500 font-normal font-inter text-xs text-left">
+                                Status
+                              </th>
+                              <th className="px-3 py-2 text-gray-500 font-normal font-inter text-xs text-left">
+                                Error
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {(broadcastJob.result.results || [])
+                              .slice(0, 20)
+                              .map((result: any) => (
+                                <tr
+                                  key={`${result.chatName}-${result.status}`}
+                                  className="border-t border-gray-100"
+                                >
+                                  <td className="px-3 py-2 font-sans text-xs">
+                                    {result.chatName}
+                                  </td>
+                                  <td className="px-3 py-2 font-mono text-xs">
+                                    {result.status}
+                                  </td>
+                                  <td className="px-3 py-2 font-sans text-xs text-gray-600">
+                                    {result.error || ''}
+                                  </td>
+                                </tr>
+                              ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  )}
+                {broadcastJob?.state === 'failed' && (
+                  <div className="font-sans text-xs text-red-700 mt-2">
+                    Failed: {broadcastJob?.error || 'unknown error'}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
       {renderActionsForSelected()}
-      {showLoading && (<Loading />)}
+      {showLoading && <Loading />}
       {showCreate && (
         <Dialog
           className="fixed inset-x-0 inset-y-0 z-50 flex justify-center items-center bg-black/50 transition duration-300 ease-out data-[closed]:opacity-0"
           open={showCreate}
           transition
-          onClose={() => { }}
+          onClose={() => {}}
         >
           <DialogPanel className="p-4 sm:p-8 bg-white rounded-3xl w-full max-w-[640px] m-8 relative">
             <button
@@ -298,9 +613,13 @@ export function Chats({ allowUsersToCreateRooms, setAllowUsersToCreateRooms, def
       )}
       {showDelete && (
         <SubmitModal onClose={() => setShowDelete(false)}>
-          <div className="font-varela text-[24px] text-center mb-8">Delete App Room</div>
+          <div className="font-varela text-[24px] text-center mb-8">
+            Delete App Room
+          </div>
           <p className="font-sans text-[14px] mb-8 text-center">
-            {`Are you sure you want to delete ${getSelectedIndexes().length} ${getSelectedIndexes().length > 1 ? 'rooms' : 'room'}?`}
+            {`Are you sure you want to delete ${getSelectedIndexes().length} ${
+              getSelectedIndexes().length > 1 ? 'rooms' : 'room'
+            }?`}
           </p>
           <div className="flex gap-8">
             <button


### PR DESCRIPTION
## Summary
- restore the app-settings broadcast message UI for all chats or selected pinned chats
- add app-authenticated v2 broadcast helpers so admin broadcast requests use the app token and do not trigger user logout flows on 401
- show async broadcast job state, progress, and first-result details directly in the chats settings tab

## Test plan
- [x] `npm run typecheck`
- [x] checked IDE lints for touched files
- [ ] manually verify sending to all chats from app settings on a backend with `/v2/chats/broadcast` enabled
- [ ] manually verify sending to selected pinned chats and job polling details

## Notes
- this ports the useful admin broadcast work from the earlier `dev-tf` line onto current `dev`
- it intentionally does not include the separate `AdminApps` default sorting change from the preserve branch