### PR TITLE
fix(auth): repack hubspot, cookie, and turnstile updates onto dev

### DIFF
--- a/src/components/Sorting.tsx
+++ b/src/components/Sorting.tsx
@@ -19,7 +19,7 @@ interface OrderItem {
 
 interface Props<T extends string> {
   orderByList: Array<OrderItem>;
-  order: string;
+  order: 'asc' | 'desc';
   setOrder: (s: 'asc' | 'desc') => void;
   orderBy: T;
   setOrderBy: (s: T) => void;

--- a/src/components/UI/Pagination/Pagination.tsx
+++ b/src/components/UI/Pagination/Pagination.tsx
@@ -12,6 +12,8 @@ export const Pagination: FC<PaginationProps> = ({
   pageCount,
   forcePage,
 }) => {
+  const safeForcePage = pageCount > 0 ? Math.min(forcePage, pageCount - 1) : 0;
+
   return (
     <ReactPaginate
       className="flex flex-wrap items-center justify-center gap-2 mt-4 text-gray-500 w-full max-w-full overflow-hidden"
@@ -21,7 +23,7 @@ export const Pagination: FC<PaginationProps> = ({
       previousLabel="← Prev"
       pageRangeDisplayed={2}
       pageCount={pageCount}
-      forcePage={forcePage}
+      forcePage={safeForcePage}
       renderOnZeroPageCount={null}
       activeClassName="text-brand-500 font-bold px-3 py-2 rounded"
       pageClassName="px-2 py-1 sm:px-3 sm:py-2 hover:bg-gray-200"

--- a/src/components/UI/Pagination/Pagination.tsx
+++ b/src/components/UI/Pagination/Pagination.tsx
@@ -12,7 +12,7 @@ export const Pagination: FC<PaginationProps> = ({
   pageCount,
   forcePage,
 }) => {
-  const safeForcePage = pageCount > 0 ? Math.min(forcePage, pageCount - 1) : 0;
+  const safeForcePage = pageCount > 0 ? Math.min(forcePage, pageCount - 1) : undefined;
 
   return (
     <ReactPaginate

--- a/src/components/modal/SettingsTutorialModal/components/HubspotForm.tsx
+++ b/src/components/modal/SettingsTutorialModal/components/HubspotForm.tsx
@@ -17,6 +17,14 @@ declare global {
 
 export const HubspotForm = () => {
   useEffect(() => {
+    const enabled = String(import.meta.env.VITE_HUBSPOT_ENABLED || '').toLowerCase() === 'true';
+    const portalId = String(import.meta.env.VITE_HUBSPOT_PORTAL_ID || '').trim();
+    const formId = String(import.meta.env.VITE_HUBSPOT_FORM_ID_TUTORIAL || '').trim();
+    const region = String(import.meta.env.VITE_HUBSPOT_REGION || 'na1').trim();
+
+    // Enterprise/self-hosted safety: do not load HubSpot unless explicitly enabled + configured
+    if (!enabled || !portalId || !formId) return;
+
     const script = document.createElement('script');
     script.src = 'https://js.hsforms.net/forms/embed/v2.js';
     script.async = true;
@@ -25,9 +33,9 @@ export const HubspotForm = () => {
     script.onload = () => {
       if (window.hbspt) {
         window.hbspt.forms.create({
-          region: 'na1',
-          portalId: '4732608',
-          formId: '86cdc2e8-2221-44b0-a926-02bec92c1bed',
+          region,
+          portalId,
+          formId,
           target: '#hubspot-form-wrapper'
         });
       }

--- a/src/hooks/useCentrifuge.ts
+++ b/src/hooks/useCentrifuge.ts
@@ -1,8 +1,19 @@
 import { useEffect, useState } from 'react';
 import { Centrifuge } from 'centrifuge';
-import { useAppStore } from '../store/useAppStore';import { refreshToken } from '../http';
+import { refreshToken } from '../http';
+import { useAppStore } from '../store/useAppStore';
 
-const VITE_APP_CENTRIFUGE_SERVICE = import.meta.env.VITE_APP_CENTRIFUGE_SERVICE;
+function getDefaultCentrifugeEndpoint() {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.host}/connection/websocket`;
+}
+
+const VITE_APP_CENTRIFUGE_SERVICE =
+  import.meta.env.VITE_APP_CENTRIFUGE_SERVICE || getDefaultCentrifugeEndpoint();
 
 type CounterType =
   | 'counter_chats'
@@ -32,6 +43,11 @@ export function useCentrifugeChannel() {
   }
 
   useEffect(() => {
+    if (!VITE_APP_CENTRIFUGE_SERVICE) {
+      setConnected(false);
+      return;
+    }
+
     const token = currentUser?.wsToken;
     
     const centrifuge = new Centrifuge(VITE_APP_CENTRIFUGE_SERVICE, {

--- a/src/pages/AdminApps.tsx
+++ b/src/pages/AdminApps.tsx
@@ -173,8 +173,6 @@ export default function AdminApps() {
     setShowModal(!apps.length);
   }, [apps.length]);
 
-  console.log('newShowModal', newShowModal);
-
   useEffect(() => {
     fetchApps();
   }, [fetchApps]);

--- a/src/pages/AdminApps.tsx
+++ b/src/pages/AdminApps.tsx
@@ -44,7 +44,7 @@ export default function AdminApps() {
     [searchParams]
   );
   const orderBy = useMemo(
-    () => (searchParams.get('orderBy') as OrderByType) || 'totalRegistered',
+    () => (searchParams.get('orderBy') as OrderByType) || 'createdAt',
     [searchParams]
   );
 

--- a/src/pages/AuthPage/FacebookButton.tsx
+++ b/src/pages/AuthPage/FacebookButton.tsx
@@ -14,6 +14,10 @@ import CustomButton from './Button.tsx';
 import { getUserCredsFromFacebook } from './firebase';
 import FacebookIcon from './Icons/socials/facebookIcon';
 
+const HUBSPOT_ENABLED = String(import.meta.env.VITE_HUBSPOT_ENABLED || '').toLowerCase() === 'true';
+const HUBSPOT_PORTAL_ID = String(import.meta.env.VITE_HUBSPOT_PORTAL_ID || '').trim();
+const HUBSPOT_FORM_ID_SIGNUP = String(import.meta.env.VITE_HUBSPOT_FORM_ID_SIGNUP || '').trim();
+
 export const FacebookButton = () => {
   const config = useAppStore((s) => s.currentApp);
   const navigate = useNavigate();
@@ -64,20 +68,18 @@ export const FacebookButton = () => {
               return;
             }
 
-            const hubspotData = {
-              fields: [
-                { name: 'firstname', value: firstName },
-                { name: 'lastname', value: lastName },
-                { name: 'email', value: email },
-                { name: 'website', value: website },
-              ],
-            };
+            if (HUBSPOT_ENABLED && HUBSPOT_PORTAL_ID && HUBSPOT_FORM_ID_SIGNUP) {
+              const hubspotData = {
+                fields: [
+                  { name: 'firstname', value: firstName },
+                  { name: 'lastname', value: lastName },
+                  { name: 'email', value: email },
+                  { name: 'website', value: website },
+                ],
+              };
 
-            await sendHSFormData(
-              '4732608',
-              '1bf4cbda-8d42-4bfc-8015-c41304eabf19',
-              hubspotData
-            );
+              await sendHSFormData(HUBSPOT_PORTAL_ID, HUBSPOT_FORM_ID_SIGNUP, hubspotData);
+            }
           } catch (error) {
             console.error(error);
             toast.error('Social registration failed');

--- a/src/pages/AuthPage/GoogleButton.tsx
+++ b/src/pages/AuthPage/GoogleButton.tsx
@@ -14,6 +14,13 @@ import { navigateToUserPage } from '../../utils/navigateToUserPage';
 import CustomButton from './Button';
 import GoogleIcon from './Icons/socials/googleIcon';
 
+const ROOT_DOMAIN = String(import.meta.env.VITE_ROOT_DOMAIN || '').trim();
+function setEthoraUserCookie(value: string) {
+  const domainPart =
+    ROOT_DOMAIN && ROOT_DOMAIN !== 'localhost' ? `; domain=.${ROOT_DOMAIN}` : '';
+  document.cookie = `ethora_user=${value}; path=/${domainPart}; secure; samesite=lax; max-age=604800`;
+}
+
 interface GoogleButtonProps {
   utm?: string | null;
 }
@@ -79,23 +86,22 @@ export const GoogleButton = ({ utm }: GoogleButtonProps) => {
               return;
             }
 
-            const hubspotData = {
-              fields: [
-                { name: 'firstname', value: firstName },
-                { name: 'lastname', value: lastName },
-                { name: 'email', value: email },
-                { name: 'website', value: website },
-              ],
-            };
+            const hubspotEnabled = String(import.meta.env.VITE_HUBSPOT_ENABLED || '').toLowerCase() === 'true';
+            const portalId = String(import.meta.env.VITE_HUBSPOT_PORTAL_ID || '').trim();
+            const formId = String(import.meta.env.VITE_HUBSPOT_FORM_ID_SIGNUP || '').trim();
+            if (hubspotEnabled && portalId && formId) {
+              const hubspotData = {
+                fields: [
+                  { name: 'firstname', value: firstName },
+                  { name: 'lastname', value: lastName },
+                  { name: 'email', value: email },
+                  { name: 'website', value: website },
+                ],
+              };
+              await sendHSFormData(portalId, formId, hubspotData);
+            }
 
-            await sendHSFormData(
-              '4732608',
-              '1bf4cbda-8d42-4bfc-8015-c41304eabf19',
-              hubspotData
-            );
-
-            document.cookie =
-              'ethora_user=accregred; path=/; domain=.ethora.com; secure; samesite=lax; max-age=604800';
+            setEthoraUserCookie('accregred');
           } catch (error) {
             console.error(error);
             toast.error('Social registration failed');
@@ -107,8 +113,7 @@ export const GoogleButton = ({ utm }: GoogleButtonProps) => {
             loginType
           ).then(async ({ data }) => {
             await actionAfterLogin(data);
-            document.cookie =
-              'ethora_user=accregred; path=/; domain=.ethora.com; secure; samesite=lax; max-age=604800';
+            setEthoraUserCookie('accregred');
             localStorage.setItem('newUser', true.toString());
 
             navigateToUserPage(navigate, config?.afterLoginPage);
@@ -123,8 +128,7 @@ export const GoogleButton = ({ utm }: GoogleButtonProps) => {
             logLogin('google', data.user._id);
 
             await actionAfterLogin(data);
-            document.cookie =
-              'ethora_user=accregred; path=/; domain=.ethora.com; secure; samesite=lax; max-age=604800';
+            setEthoraUserCookie('accregred');
 
             navigateToUserPage(navigate, config?.afterLoginPage);
           });

--- a/src/pages/AuthPage/Login/Steps/LoginForm.tsx
+++ b/src/pages/AuthPage/Login/Steps/LoginForm.tsx
@@ -14,6 +14,13 @@ import CustomButton from '../../Button';
 import { GoogleButton } from '../../GoogleButton';
 import { MetamaskButton } from '../../MetamaskButton';
 
+const ROOT_DOMAIN = String(import.meta.env.VITE_ROOT_DOMAIN || '').trim();
+function setEthoraUserCookie(value: string) {
+  const domainPart =
+    ROOT_DOMAIN && ROOT_DOMAIN !== 'localhost' ? `; domain=.${ROOT_DOMAIN}` : '';
+  document.cookie = `ethora_user=${value}; path=/${domainPart}; secure; samesite=lax; max-age=604800`;
+}
+
 type Inputs = {
   email: string;
   password: string;
@@ -33,10 +40,8 @@ const LoginStep = () => {
     httpLoginWithEmail(email, password)
       .then(async ({ data }) => {
         await actionAfterLogin(data);
-
         logLogin('email', data.user._id);
-        document.cookie =
-          'ethora_user=1; path=/; domain=.ethora.com; secure; samesite=lax; max-age=604800';
+        setEthoraUserCookie('1');
 
         if (config?.afterLoginPage) {
           navigateToUserPage(navigate, config.afterLoginPage as string);

--- a/src/pages/AuthPage/MetamaskButton.tsx
+++ b/src/pages/AuthPage/MetamaskButton.tsx
@@ -18,6 +18,13 @@ import { navigateToUserPage } from '../../utils/navigateToUserPage';
 import CustomButton from './Button';
 import MetamaskIcon from './Icons/socials/metamaskIcon';
 
+const ROOT_DOMAIN = String(import.meta.env.VITE_ROOT_DOMAIN || '').trim();
+function setEthoraUserCookie(value: string) {
+  const domainPart =
+    ROOT_DOMAIN && ROOT_DOMAIN !== 'localhost' ? `; domain=.${ROOT_DOMAIN}` : '';
+  document.cookie = `ethora_user=${value}; path=/${domainPart}; secure; samesite=lax; max-age=604800`;
+}
+
 declare global {
   interface Window {
     ethereum?: any;
@@ -55,8 +62,7 @@ export const MetamaskButton = ({ utm }: MetamaskButtonProps) => {
 
     toast.success('Successfully logged in with Metamask!');
 
-    document.cookie =
-      'ethora_user=accregred; path=/; domain=.ethora.com; secure; samesite=lax; max-age=604800';
+    setEthoraUserCookie('accregred');
 
     if (config?.afterLoginPage) {
       navigateToUserPage(navigate, config.afterLoginPage as string);

--- a/src/pages/AuthPage/Register/RegisterForm.tsx
+++ b/src/pages/AuthPage/Register/RegisterForm.tsx
@@ -24,6 +24,14 @@ import SkeletonLoader from '../SkeletonLoader';
 
 const SITE_KEY = (import.meta.env.VITE_SITE_KEY || '').trim();
 const TURNSTILE_ENABLED = SITE_KEY.length > 0;
+const ROOT_DOMAIN = String(import.meta.env.VITE_ROOT_DOMAIN || '').trim();
+
+function setEthoraUserCookie(value: string) {
+  const domainPart =
+    ROOT_DOMAIN && ROOT_DOMAIN !== 'localhost' ? `; domain=.${ROOT_DOMAIN}` : '';
+  // Keep existing behavior, but avoid hardcoding ethora.com for enterprise/self-hosted installs
+  document.cookie = `ethora_user=${value}; path=/${domainPart}; secure; samesite=lax; max-age=604800`;
+}
 
 interface FirstStepProps {
   isSmallDevice?: boolean;
@@ -164,9 +172,16 @@ const RegisterForm: React.FC<FirstStepProps> = ({ isSmallDevice = false }) => {
           return;
         }
 
+        const hubspotEnabled = String(import.meta.env.VITE_HUBSPOT_ENABLED || '').toLowerCase() === 'true';
+        const portalId = String(import.meta.env.VITE_HUBSPOT_PORTAL_ID || '').trim();
+        const formId = String(import.meta.env.VITE_HUBSPOT_FORM_ID_SIGNUP || '').trim();
+        if (!hubspotEnabled || !portalId || !formId) {
+          return;
+        }
+
         await sendHSFormData(
-          '4732608',
-          '1bf4cbda-8d42-4bfc-8015-c41304eabf19',
+          portalId,
+          formId,
           hubspotData
         );
       });
@@ -178,8 +193,7 @@ const RegisterForm: React.FC<FirstStepProps> = ({ isSmallDevice = false }) => {
 
       httpLoginWithEmail(email, password)
         .then(async ({ data }) => {
-          document.cookie =
-            'ethora_user=1; path=/; domain=.ethora.com; secure; samesite=lax; max-age=604800';
+          setEthoraUserCookie('1');
           localStorage.setItem('newUser', true.toString());
 
           await actionAfterLogin(data);

--- a/src/pages/AuthPage/Register/RegisterForm.tsx
+++ b/src/pages/AuthPage/Register/RegisterForm.tsx
@@ -22,7 +22,8 @@ import { GoogleButton } from '../GoogleButton';
 import { MetamaskButton } from '../MetamaskButton';
 import SkeletonLoader from '../SkeletonLoader';
 
-const SITE_KEY = import.meta.env.VITE_SITE_KEY;
+const SITE_KEY = (import.meta.env.VITE_SITE_KEY || '').trim();
+const TURNSTILE_ENABLED = SITE_KEY.length > 0;
 
 interface FirstStepProps {
   isSmallDevice?: boolean;
@@ -129,7 +130,10 @@ const RegisterForm: React.FC<FirstStepProps> = ({ isSmallDevice = false }) => {
     const formData = new FormData(formRef.current!);
     const cfToken = formData.get('cf-turnstile-response');
 
-    if (!cfToken || typeof cfToken !== 'string' || cfToken.trim() === '') {
+    // Turnstile is optional for enterprise installs; if VITE_SITE_KEY is empty we skip it.
+    const cfTokenValue =
+      typeof cfToken === 'string' ? cfToken.trim() : '';
+    if (TURNSTILE_ENABLED && !cfTokenValue) {
       return;
     }
 
@@ -137,7 +141,7 @@ const RegisterForm: React.FC<FirstStepProps> = ({ isSmallDevice = false }) => {
       await httpRegisterWithEmailV2(
         email,
         password,
-        cfToken,
+        cfTokenValue,
         firstName,
         lastName,
         utmParams || ''
@@ -311,12 +315,14 @@ const RegisterForm: React.FC<FirstStepProps> = ({ isSmallDevice = false }) => {
             helperText={errors.password?.message}
           />
           <Box className="flex justify-center items-center">
-            <Turnstile
-              options={{
-                theme: 'light',
-              }}
-              siteKey={SITE_KEY}
-            />
+            {TURNSTILE_ENABLED && (
+              <Turnstile
+                options={{
+                  theme: 'light',
+                }}
+                siteKey={SITE_KEY}
+              />
+            )}
           </Box>
           <CustomButton
             type="submit"

--- a/src/pages/AuthPage/Register/Steps/FirstStep.tsx
+++ b/src/pages/AuthPage/Register/Steps/FirstStep.tsx
@@ -22,6 +22,14 @@ import { GoogleButton } from '../../GoogleButton';
 import { MetamaskButton } from '../../MetamaskButton';
 import SkeletonLoader from '../../SkeletonLoader';
 
+const ROOT_DOMAIN = String(import.meta.env.VITE_ROOT_DOMAIN || '').trim();
+
+function setEthoraUserCookie(value: string) {
+  const domainPart =
+    ROOT_DOMAIN && ROOT_DOMAIN !== 'localhost' ? `; domain=.${ROOT_DOMAIN}` : '';
+  document.cookie = `ethora_user=${value}; path=/${domainPart}; secure; samesite=lax; max-age=604800`;
+}
+
 interface FirstStepProps {
   setStep: Dispatch<SetStateAction<number>>;
   isSmallDevice?: boolean;
@@ -164,9 +172,16 @@ const FirstStep: React.FC<FirstStepProps> = ({ isSmallDevice = false }) => {
           return;
         }
 
+        const hubspotEnabled = String(import.meta.env.VITE_HUBSPOT_ENABLED || '').toLowerCase() === 'true';
+        const portalId = String(import.meta.env.VITE_HUBSPOT_PORTAL_ID || '').trim();
+        const formId = String(import.meta.env.VITE_HUBSPOT_FORM_ID_SIGNUP || '').trim();
+        if (!hubspotEnabled || !portalId || !formId) {
+          return;
+        }
+
         await sendHSFormData(
-          '4732608',
-          '1bf4cbda-8d42-4bfc-8015-c41304eabf19',
+          portalId,
+          formId,
           hubspotData
         );
       });
@@ -178,8 +193,7 @@ const FirstStep: React.FC<FirstStepProps> = ({ isSmallDevice = false }) => {
 
       httpLoginWithEmail(email, password)
         .then(async ({ data }) => {
-          document.cookie =
-            'ethora_user=1; path=/; domain=.ethora.com; secure; samesite=lax; max-age=604800';
+          setEthoraUserCookie('1');
 
           await actionAfterLogin(data);
 

--- a/src/pages/AuthPage/Register/Steps/ThirdStep.tsx
+++ b/src/pages/AuthPage/Register/Steps/ThirdStep.tsx
@@ -13,6 +13,13 @@ import { navigateToUserPage } from '../../../../utils/navigateToUserPage';
 import CustomButton from '../../Button';
 import SkeletonLoader from '../../SkeletonLoader';
 
+const ROOT_DOMAIN = String(import.meta.env.VITE_ROOT_DOMAIN || '').trim();
+function setEthoraUserCookie(value: string) {
+  const domainPart =
+    ROOT_DOMAIN && ROOT_DOMAIN !== 'localhost' ? `; domain=.${ROOT_DOMAIN}` : '';
+  document.cookie = `ethora_user=${value}; path=/${domainPart}; secure; samesite=lax; max-age=604800`;
+}
+
 interface Inputs {
   newPassword: string;
   repeatPassword: string;
@@ -103,8 +110,7 @@ const ThirdStep = () => {
 
         httpLoginWithEmail(email, newPassword)
           .then(async ({ data }) => {
-            document.cookie =
-              'ethora_user=1; path=/; domain=.ethora.com; secure; samesite=lax; max-age=604800';
+            setEthoraUserCookie('1');
 
             await actionAfterLogin(data);
 

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -20,14 +20,23 @@ const MemoizedChat = React.memo(function ChatComponent({
 }: ChatComponentProps) {
   const appToken = useAppStore((s) => s.currentApp?.appToken);
 
-  const handleChangeTokens = async () => {
-    const { token, refreshToken: refresh } = await refreshToken();
+  const handleChangeTokens = async (): Promise<
+    | { accessToken: string; refreshToken?: string | undefined }
+    | null
+  > => {
+    try {
+      const { token, refreshToken: refresh } = await refreshToken();
 
-    localStorage.setItem('refreshToken-538', refresh);
-    localStorage.setItem('token-538', token);
+      if (refresh) localStorage.setItem('refreshToken-538', refresh);
+      localStorage.setItem('token-538', token);
 
-    httpTokens.token = token;
-    httpTokens.refreshToken = refresh;
+      httpTokens.token = token;
+      httpTokens.refreshToken = refresh;
+
+      return { accessToken: token, refreshToken: refresh };
+    } catch (e) {
+      return null;
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- repack the still-relevant auth, HubSpot, cookie-domain, and optional Turnstile work from the old `dev-tf` line onto current `dev`
- make HubSpot behavior env-gated and switch auth cookie handling to configurable root-domain logic instead of hard-coded production-only assumptions
- keep Turnstile optional and harden auth-related frontend flows around registration and login surfaces

## Test plan
- [x] `npm run typecheck`
- [x] checked IDE lints for touched files
- [ ] manually verify email login and registration on local and staging
- [ ] manually verify Google/Metamask/Facebook auth surfaces under the intended env flags
- [ ] manually verify HubSpot form behavior when the feature is enabled vs disabled

## Notes
- this supersedes the auth/config part of the old `dev-tf` rollup PR
- runtime/dev-environment stability and chat broadcast were split into separate focused PRs for easier review