### PR TITLE
feat(sources): offer a re-crawl when the URL is already indexed

### DIFF
--- a/src/components/Agents/panels/AgentPanels.tsx
+++ b/src/components/Agents/panels/AgentPanels.tsx
@@ -20,6 +20,7 @@ import {
 import {
   httpAgentDocsUpload,
   httpAgentSiteCrawl,
+  alreadyIndexedUrl,
   httpDeleteDocSourceV2,
   httpDeleteSiteSourceV2Url,
   httpDiagAgentBotInstance,
@@ -370,6 +371,36 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
     return loadList(stayOnPage ? offset : Math.max(0, offset - SITE_SOURCES_PAGE_SIZE));
   };
 
+  const crawlOnce = async (force: boolean) => {
+    await httpAgentSiteCrawl(appId, agent.id, url, followLink, force);
+    toast.success(t('agentPanels.crawlQueued'));
+    setUrl('');
+    // Re-fetch from the first page: new rows sort newest-first, so they
+    // land at the top regardless of where the operator was paging.
+    await loadList(0);
+  };
+
+  const handleCrawl = async () => {
+    setBusy(true);
+    try {
+      try {
+        await crawlOnce(false);
+      } catch (e) {
+        // A URL already in this app's list is a prompt, not a failure: offer the
+        // overwrite instead of making the operator delete the row first. Declining
+        // leaves the URL in the input, so it can be edited rather than retyped.
+        const indexedUrl = alreadyIndexedUrl(e, url);
+        if (indexedUrl === null) throw e;
+        if (!confirm(t('agentPanels.confirmRecrawlIndexed').replace('{url}', indexedUrl))) return;
+        await crawlOnce(true);
+      }
+    } catch (e: any) {
+      toast.error(`${t('agentPanels.crawlFailedPrefix')} ${e?.response?.data?.error || e.message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const pageStart = total === 0 ? 0 : offset + 1;
   const pageEnd = offset + rows.length;
   const hasPrev = offset > 0;
@@ -403,21 +434,7 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
         </label>
         <button
           disabled={isDisabled || busy || !url || !appId}
-          onClick={async () => {
-            setBusy(true);
-            try {
-              await httpAgentSiteCrawl(appId, agent.id, url, followLink);
-              toast.success(t('agentPanels.crawlQueued'));
-              setUrl('');
-              // Re-fetch from the first page: new rows sort newest-first, so they
-              // land at the top regardless of where the operator was paging.
-              await loadList(0);
-            } catch (e: any) {
-              toast.error(`${t('agentPanels.crawlFailedPrefix')} ${e?.response?.data?.error || e.message}`);
-            } finally {
-              setBusy(false);
-            }
-          }}
+          onClick={handleCrawl}
           className="bg-brand-500 hover:bg-brand-400 text-white rounded px-4 py-2 disabled:opacity-50"
         >
           {busy ? t('agentPanels.crawling') : t('agentPanels.crawl')}

--- a/src/http.ts
+++ b/src/http.ts
@@ -712,10 +712,26 @@ export const sendHSFormData = async (
 };
 
 
-export function setSourcesSiteCrawl(appId: string, url: string, followLink: boolean) {
+// A site-crawl POST answers 409 SITE_SOURCE_ALREADY_INDEXED when the URL is
+// already in the app's Web Index instead of adding a second row for the same
+// page. Returns the URL to show in the "crawl it again?" prompt (the stored
+// spelling, which can differ from what was typed), or null for any other error.
+export function alreadyIndexedUrl(error: unknown, fallbackUrl: string): string | null {
+  const res = (error as {
+    response?: { status?: number; data?: { code?: string; details?: { existingUrl?: string } } };
+  })?.response;
+  if (res?.status !== 409 || res?.data?.code !== 'SITE_SOURCE_ALREADY_INDEXED') return null;
+  return res.data?.details?.existingUrl || fallbackUrl;
+}
+
+// `force` re-crawls a URL that is already indexed, overwriting the stored copy.
+// Without it the backend answers 409 SITE_SOURCE_ALREADY_INDEXED rather than
+// adding a second row for the same page.
+export function setSourcesSiteCrawl(appId: string, url: string, followLink: boolean, force = false) {
   return http.post(`/sources/site-crawl/${appId}`, {
     url,
-    followLink
+    followLink,
+    force
   });
 }
 
@@ -866,8 +882,12 @@ export function httpSetBotInstanceStatus(id: string, status: 'on' | 'off') {
 
 // Per-Agent source ingestion. These reuse the same endpoints as the per-App calls but
 // pass an explicit agentId so docs land in the agent's RAG namespace.
-export function httpAgentSiteCrawl(appId: string, agentId: string, url: string, followLink: boolean) {
-  return httpV2.post(`/apps/${appId}/sources/site-crawl`, { url, followLink, agentId });
+// `force` opts out of the already-indexed check: the URL is re-crawled and the
+// stored copy overwritten. Without it a URL already present in the app's Web
+// Index list comes back as 409 SITE_SOURCE_ALREADY_INDEXED instead of being
+// silently added a second time.
+export function httpAgentSiteCrawl(appId: string, agentId: string, url: string, followLink: boolean, force = false) {
+  return httpV2.post(`/apps/${appId}/sources/site-crawl`, { url, followLink, agentId, force });
 }
 
 export function httpAgentDocsUpload(appId: string, agentId: string, files: File[]) {

--- a/src/i18n/translations/aiWidget.ts
+++ b/src/i18n/translations/aiWidget.ts
@@ -241,6 +241,8 @@ export const aiWidget = {
     'agentPanels.crawl': 'Crawl',
     'agentPanels.crawlQueued': 'Crawl queued',
     'agentPanels.crawlFailedPrefix': 'Crawl failed:',
+    'agentPanels.confirmRecrawlIndexed':
+      '{url} is already indexed. Crawl it again and replace the stored copy?',
     'agentPanels.indexedBytesPrefix': 'Indexed bytes:',
     'agentPanels.indexedUrlsSuffixOne': 'indexed URL in this app',
     'agentPanels.indexedUrlsSuffixOther': 'indexed URLs in this app',
@@ -586,6 +588,8 @@ export const aiWidget = {
     'agentPanels.crawl': 'Explorer',
     'agentPanels.crawlQueued': "Exploration mise en file d'attente",
     'agentPanels.crawlFailedPrefix': "Échec de l'exploration :",
+    'agentPanels.confirmRecrawlIndexed':
+      '{url} est déjà indexée. Explorer à nouveau et remplacer la copie enregistrée ?',
     'agentPanels.indexedBytesPrefix': 'Octets indexés :',
     'agentPanels.indexedUrlsSuffixOne': 'URL indexée dans cette application',
     'agentPanels.indexedUrlsSuffixOther':
@@ -939,6 +943,8 @@ export const aiWidget = {
     'agentPanels.crawl': 'Rastrear',
     'agentPanels.crawlQueued': 'Rastreo en cola',
     'agentPanels.crawlFailedPrefix': 'Error al rastrear:',
+    'agentPanels.confirmRecrawlIndexed':
+      '{url} ya está indexada. ¿Rastrearla de nuevo y reemplazar la copia guardada?',
     'agentPanels.indexedBytesPrefix': 'Bytes indexados:',
     'agentPanels.indexedUrlsSuffixOne': 'URL indexada en esta aplicación',
     'agentPanels.indexedUrlsSuffixOther':

--- a/src/i18n/translations/appSettings1.ts
+++ b/src/i18n/translations/appSettings1.ts
@@ -38,6 +38,8 @@ export const appSettings1 = {
     'appSettings.toast.reindexFailed': 'Failed to reindex site crawl',
     'appSettings.toast.siteCrawlSet': 'Site crawl set successfully',
     'appSettings.toast.siteCrawlFailed': 'Failed to set site crawl',
+    'appSettings.confirmRecrawlIndexed':
+      '{url} is already indexed. Crawl it again and replace the stored copy?',
     'appSettings.toast.linksDeleted': 'Selected links successfully deleted',
     'appSettings.toast.noLinksDeleted': 'None of the links could be deleted.',
     'appSettings.toast.deleteLinksError':
@@ -236,6 +238,8 @@ export const appSettings1 = {
       "Exploration du site configurée avec succès",
     'appSettings.toast.siteCrawlFailed':
       "Échec de la configuration de l'exploration du site",
+    'appSettings.confirmRecrawlIndexed':
+      '{url} est déjà indexée. Explorer à nouveau et remplacer la copie enregistrée ?',
     'appSettings.toast.linksDeleted':
       'Liens sélectionnés supprimés avec succès',
     'appSettings.toast.noLinksDeleted':
@@ -457,6 +461,8 @@ export const appSettings1 = {
       'Rastreo del sitio configurado correctamente',
     'appSettings.toast.siteCrawlFailed':
       'No se pudo configurar el rastreo del sitio',
+    'appSettings.confirmRecrawlIndexed':
+      '{url} ya está indexada. ¿Rastrearla de nuevo y reemplazar la copia guardada?',
     'appSettings.toast.linksDeleted':
       'Los enlaces seleccionados se eliminaron correctamente',
     'appSettings.toast.noLinksDeleted':

--- a/src/pages/AppSettings/AppSettings.tsx
+++ b/src/pages/AppSettings/AppSettings.tsx
@@ -22,6 +22,7 @@ import {
   httpUpdateOneUser,
   setSourcesSiteCrawl,
   setSourcesSiteCrawlReindex,
+  alreadyIndexedUrl,
 } from '../../http';
 import { useTranslation } from '../../i18n/useTranslation';
 import {
@@ -508,8 +509,8 @@ export default function AppSettings() {
 
     setLoadingTextCrawl(true);
 
-    try {
-      const response = await setSourcesSiteCrawl(appId, url, followLink);
+    const crawlOnce = async (force: boolean) => {
+      const response = await setSourcesSiteCrawl(appId, url, followLink, force);
       setAiBot((prev) => {
         const combined = [
           ...prev.siteUrlsV2,
@@ -521,6 +522,24 @@ export default function AppSettings() {
         return { ...prev, siteUrlsV2: uniqueById };
       });
       toast.success(t('appSettings.toast.siteCrawlSet'));
+    };
+
+    try {
+      try {
+        await crawlOnce(false);
+      } catch (error) {
+        // The URL is already in this app's index. Offer to overwrite it rather
+        // than reporting a failure the operator can do nothing about.
+        const indexedUrl = alreadyIndexedUrl(error, url);
+        if (indexedUrl === null) throw error;
+        if (
+          !confirm(
+            t('appSettings.confirmRecrawlIndexed').replace('{url}', indexedUrl)
+          )
+        )
+          return;
+        await crawlOnce(true);
+      }
     } catch (error) {
       console.error('Error setting site crawl:', error);
       toast.error(t('appSettings.toast.siteCrawlFailed'));


### PR DESCRIPTION
## Problem

The site-crawl endpoints now answer `409 SITE_SOURCE_ALREADY_INDEXED` instead of adding a second Web Index row for a page the app already holds (see dappros/ethora-backend#116). Surfacing that as a plain error toast would leave the operator with no way forward short of deleting the existing row.

## Change

Both crawl entry points catch the 409 and ask whether to crawl the URL again and replace the stored copy, retrying with `force: true` on confirm:

- **Agents → Web Index** panel (`AgentPanels.tsx`)
- **legacy AI Widget** site-crawl tab (`AppSettings.tsx`) — shares the endpoint, and would otherwise show a generic "Failed to set site crawl" with no explanation

Declining leaves the URL in the input so it can be edited rather than retyped.

The prompt shows the **stored** spelling of the URL (`details.existingUrl`), not what was typed — the two can differ, since host case, trailing slash and fragments all match the same page, and it is useful to see what the input actually collided with.

The 409 shape is narrowed once in `http.ts` (`alreadyIndexedUrl`), so neither call site needs an `any` cast.

New i18n keys `agentPanels.confirmRecrawlIndexed` and `appSettings.confirmRecrawlIndexed` in all three locales (en/fr/es).

`WpSetup` is deliberately untouched: it crawls immediately after creating the app and agent, so the index is empty and a duplicate is not reachable.

## Testing

- `npm run typecheck` clean, `npm run build` passes
- eslint: **0 new errors** — verified by stash comparison (components 21 errors/7 warnings before and after; `http.ts` 24/24 before and after)

## Deploy note

Pairs with dappros/ethora-backend#116. Order is not critical — this frontend against an older backend simply never sees a 409 and behaves exactly as before — but ship them together for the intended UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)