### PR TITLE
feat(agents): view the stored markdown of an indexed URL

### DIFF
--- a/src/components/Agents/panels/AgentPanels.tsx
+++ b/src/components/Agents/panels/AgentPanels.tsx
@@ -36,6 +36,7 @@ import { useTranslation } from '../../../i18n/useTranslation';
 import { ModelAgent, ModelAppDefaulRooom, ModelBotInstance } from '../../../models';
 import { agentPromptTemplates } from '../../../constants/agentPromptTemplates';
 import { useAppStore } from '../../../store/useAppStore';
+import { SiteSourceMarkdownModal } from './SiteSourceMarkdownModal';
 
 export const Field: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
   <label className="block">
@@ -330,6 +331,8 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
   // Row ids ticked for bulk removal. Held as ids rather than indexes so a
   // selection survives paging: a crawl of any size is removed in one request.
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  // Row whose stored markdown is open in the viewer, if any.
+  const [viewing, setViewing] = useState<SiteSourceRow | null>(null);
 
   // If the parent's scope wasn't usable (e.g. agent has no originAppId), fall back to
   // the user's first owned app so the UI is functional out of the box.
@@ -547,7 +550,7 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
               <th className="text-left p-2">{t('agentPanels.urlHeader')}</th>
               <th className="text-left p-2 w-24">{t('agentPanels.sizeHeader')}</th>
               <th className="text-left p-2 w-32">{t('agentPanels.updatedHeader')}</th>
-              <th className="p-2 w-28"></th>
+              <th className="p-2 w-40"></th>
             </tr>
           </thead>
           <tbody>
@@ -577,6 +580,12 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
                 <td className="p-2 text-gray-600">{fmtBytesShort(row.mdByteSize)}</td>
                 <td className="p-2 text-gray-500">{row.updatedAt ? new Date(row.updatedAt).toLocaleString() : ''}</td>
                 <td className="p-2 text-right whitespace-nowrap">
+                  <button
+                    onClick={() => setViewing(row)}
+                    className="text-brand-500 hover:underline mr-2"
+                  >
+                    {t('agentPanels.viewMarkdown')}
+                  </button>
                   <button
                     disabled={isDisabled || busy}
                     onClick={async () => {
@@ -649,6 +658,15 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
             </button>
           </div>
         </div>
+      )}
+
+      {viewing && (
+        <SiteSourceMarkdownModal
+          appId={appId}
+          sourceId={viewing.id}
+          url={viewing.url}
+          onClose={() => setViewing(null)}
+        />
       )}
     </div>
   );

--- a/src/components/Agents/panels/SiteSourceMarkdownModal.tsx
+++ b/src/components/Agents/panels/SiteSourceMarkdownModal.tsx
@@ -1,0 +1,94 @@
+import { Dialog, DialogPanel } from '@headlessui/react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from '../../../i18n/useTranslation';
+import { httpGetSiteSourceV2 } from '../../../http';
+import { CopyButton } from '../../CopyButton';
+import { IconClose } from '../../Icons/IconClose';
+
+interface Props {
+  appId: string;
+  sourceId: string;
+  // Shown in the header immediately, so the dialog has a title before the
+  // fetch lands. The response carries the same URL and wins once it arrives.
+  url: string;
+  onClose: () => void;
+}
+
+// Reads back the markdown a crawl stored for one URL. Rendered as source text
+// rather than as formatted HTML on purpose: this is the exact string that gets
+// chunked and embedded, so what an operator needs to see is what the crawler
+// extracted (missing sections, nav boilerplate, empty pages), not a tidy
+// re-rendering of it.
+export function SiteSourceMarkdownModal({ appId, sourceId, url, onClose }: Props) {
+  const { t } = useTranslation();
+  const [md, setMd] = useState('');
+  const [bytes, setBytes] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    httpGetSiteSourceV2(appId, sourceId)
+      .then((r) => {
+        if (cancelled) return;
+        setMd(r.data?.result?.md || '');
+        setBytes(Number(r.data?.result?.mdByteSize) || 0);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e?.response?.data?.error || e?.message || '');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    // Closing the dialog mid-request must not write state into a gone component.
+    return () => {
+      cancelled = true;
+    };
+  }, [appId, sourceId]);
+
+  return (
+    <Dialog open={true} onClose={onClose} className="relative z-50">
+      <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel className="bg-white rounded shadow-lg w-full max-w-3xl max-h-[85vh] flex flex-col">
+          <div className="flex items-start gap-2 border-b p-3">
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium">{t('agentPanels.markdownTitle')}</div>
+              <div className="font-mono text-xs text-gray-500 break-all mt-0.5">{url}</div>
+            </div>
+            {/* Copying the raw source is the point of the dialog, so it stays
+                reachable while the body scrolls. */}
+            {!loading && !error && md && <CopyButton value={md} />}
+            <button onClick={onClose} aria-label={t('agentPanels.closeDialog')} className="p-1">
+              <IconClose />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-auto p-3">
+            {loading && <div className="text-xs text-gray-500">{t('agentPanels.loading')}</div>}
+            {!loading && error && (
+              <div className="text-xs text-red-600">
+                {t('agentPanels.markdownLoadFailedPrefix')} {error}
+              </div>
+            )}
+            {!loading && !error && !md && (
+              <div className="text-xs text-gray-500">{t('agentPanels.markdownEmpty')}</div>
+            )}
+            {!loading && !error && md && (
+              <pre className="text-xs font-mono whitespace-pre-wrap break-words">{md}</pre>
+            )}
+          </div>
+
+          {!loading && !error && md && (
+            <div className="border-t p-2 text-xs text-gray-500">
+              {t('agentPanels.markdownBytes').replace('{n}', bytes.toLocaleString())}
+            </div>
+          )}
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -864,6 +864,13 @@ export function httpListSiteSourcesV2(appId?: string, params?: { limit?: number;
 // _ids (24-hex ObjectIds), not URL strings. Joi rejects URL strings with a
 // 422 VALIDATION_ERROR, which is why an earlier 'pass row.url' call from
 // AgentPanels silently failed. Use the row.id from listSiteSources.
+// Single Web Index row including `md`. The list endpoint omits the markdown to
+// keep a page of rows small, so this is the only way to read back what a crawl
+// actually stored for one URL.
+export function httpGetSiteSourceV2(appId: string, sourceId: string) {
+  return httpV2.get(`/apps/${appId}/sources/site-crawl/${sourceId}`);
+}
+
 // Accepts one id or many: the endpoint deletes the whole batch in a single
 // call and answers with a { summary, details } breakdown, so a bulk removal
 // does not need to be fanned out into one request per row.

--- a/src/i18n/translations/aiWidget.ts
+++ b/src/i18n/translations/aiWidget.ts
@@ -268,6 +268,12 @@ export const aiWidget = {
     'agentPanels.removedSelected': 'Removed {n} URLs',
     'agentPanels.selectAllOnPage': 'Select all URLs on this page',
     'agentPanels.selectRow': 'Select {url}',
+    'agentPanels.viewMarkdown': 'View',
+    'agentPanels.markdownTitle': 'Indexed content',
+    'agentPanels.markdownEmpty': 'No content is stored for this URL.',
+    'agentPanels.markdownLoadFailedPrefix': 'Could not load content:',
+    'agentPanels.markdownBytes': '{n} bytes of markdown',
+    'agentPanels.closeDialog': 'Close',
     'agentPanels.docsIndexDescription':
       'Upload PDFs, DOCX, MD, TXT to index under this agent.',
     'agentPanels.uploadingParsingEmbedding':
@@ -625,6 +631,12 @@ export const aiWidget = {
     'agentPanels.removedSelected': '{n} URL supprimées',
     'agentPanels.selectAllOnPage': 'Sélectionner toutes les URL de cette page',
     'agentPanels.selectRow': 'Sélectionner {url}',
+    'agentPanels.viewMarkdown': 'Voir',
+    'agentPanels.markdownTitle': 'Contenu indexé',
+    'agentPanels.markdownEmpty': "Aucun contenu n'est stocké pour cette URL.",
+    'agentPanels.markdownLoadFailedPrefix': 'Impossible de charger le contenu :',
+    'agentPanels.markdownBytes': '{n} octets de markdown',
+    'agentPanels.closeDialog': 'Fermer',
     'agentPanels.docsIndexDescription':
       'Téléversez des fichiers PDF, DOCX, MD, TXT à indexer pour cet agent.',
     'agentPanels.uploadingParsingEmbedding':
@@ -986,6 +998,12 @@ export const aiWidget = {
     'agentPanels.removedSelected': '{n} URL eliminadas',
     'agentPanels.selectAllOnPage': 'Seleccionar todas las URL de esta página',
     'agentPanels.selectRow': 'Seleccionar {url}',
+    'agentPanels.viewMarkdown': 'Ver',
+    'agentPanels.markdownTitle': 'Contenido indexado',
+    'agentPanels.markdownEmpty': 'No hay contenido almacenado para esta URL.',
+    'agentPanels.markdownLoadFailedPrefix': 'No se pudo cargar el contenido:',
+    'agentPanels.markdownBytes': '{n} bytes de markdown',
+    'agentPanels.closeDialog': 'Cerrar',
     'agentPanels.docsIndexDescription':
       'Sube archivos PDF, DOCX, MD, TXT para indexarlos en este agente.',
     'agentPanels.uploadingParsingEmbedding':


### PR DESCRIPTION
## Problem

The Web Index table showed URLs and byte sizes but gave no way to see what the crawler actually extracted. Checking whether a URL was indexed *usefully* — rather than as an empty shell, a cookie banner, or nav boilerplate — meant re-crawling it or querying Mongo directly. A healthy-looking byte count says nothing about whether the right text was captured.

## Change

Each row gets a **View** action opening a dialog with the stored markdown.

**Rendered as source text, not as formatted HTML.** This is the exact string that gets chunked and embedded, so what an operator needs to see is what the crawler extracted, not a tidy re-rendering that hides the problem. It also keeps a markdown renderer out of the dependency list — the app has none today.

Details:

- the body is copyable through the existing `CopyButton`
- the fetch is cancelled if the dialog is closed mid-request, so a slow response cannot write state into an unmounted component
- loading, empty and failed loads each have their own state rather than showing a blank panel
- the action column widened to fit the third button

## Dependency

Needs `GET /v2/apps/:appId/sources/site-crawl/:sourceId` from dappros/ethora-backend#117 — the list endpoint deliberately omits `md`. Without the backend deployed the dialog shows its error state, so this is safe to merge first but pointless until the pair lands.

## Testing

- `npm run typecheck` clean, `npm run build` passes
- eslint: **0 new errors** — verified by stash comparison (45 errors / 4 warnings before and after); the new component is clean

Not covered by automated tests: this panel has no unit tests today, and the e2e specs need a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)