### PR TITLE
feat(sources): tell the operator a crawl has started, not finished

### DIFF
--- a/src/components/Agents/panels/AgentPanels.tsx
+++ b/src/components/Agents/panels/AgentPanels.tsx
@@ -435,8 +435,10 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
     await httpAgentSiteCrawl(appId, agent.id, url, followLink, force);
     toast.success(t('agentPanels.crawlQueued'));
     setUrl('');
-    // Re-fetch from the first page: new rows sort newest-first, so they
-    // land at the top regardless of where the operator was paging.
+    // The crawler answers as soon as the job is queued, so this reload will not
+    // show the new rows yet - they land once the crawl finishes and calls back.
+    // Still worth doing: it resets paging to where those rows will appear (new
+    // rows sort newest-first) and the toast tells the operator to come back.
     await loadList(0);
   };
 

--- a/src/i18n/translations/aiWidget.ts
+++ b/src/i18n/translations/aiWidget.ts
@@ -239,7 +239,8 @@ export const aiWidget = {
     'agentPanels.followLinks': 'follow links',
     'agentPanels.crawling': 'Crawling...',
     'agentPanels.crawl': 'Crawl',
-    'agentPanels.crawlQueued': 'Crawl queued',
+    'agentPanels.crawlQueued':
+      'Crawl started. Indexed pages appear here once it finishes - reload the list in a minute.',
     'agentPanels.crawlFailedPrefix': 'Crawl failed:',
     'agentPanels.confirmRecrawlIndexed':
       '{url} is already indexed. Crawl it again and replace the stored copy?',
@@ -599,7 +600,8 @@ export const aiWidget = {
     'agentPanels.followLinks': 'suivre les liens',
     'agentPanels.crawling': 'Exploration en cours...',
     'agentPanels.crawl': 'Explorer',
-    'agentPanels.crawlQueued': "Exploration mise en file d'attente",
+    'agentPanels.crawlQueued':
+      "Exploration lancée. Les pages indexées apparaîtront ici une fois terminée - rechargez la liste dans une minute.",
     'agentPanels.crawlFailedPrefix': "Échec de l'exploration :",
     'agentPanels.confirmRecrawlIndexed':
       '{url} est déjà indexée. Explorer à nouveau et remplacer la copie enregistrée ?',
@@ -967,7 +969,8 @@ export const aiWidget = {
     'agentPanels.followLinks': 'seguir enlaces',
     'agentPanels.crawling': 'Rastreando...',
     'agentPanels.crawl': 'Rastrear',
-    'agentPanels.crawlQueued': 'Rastreo en cola',
+    'agentPanels.crawlQueued':
+      'Rastreo iniciado. Las páginas indexadas aparecerán aquí cuando termine: recarga la lista en un minuto.',
     'agentPanels.crawlFailedPrefix': 'Error al rastrear:',
     'agentPanels.confirmRecrawlIndexed':
       '{url} ya está indexada. ¿Rastrearla de nuevo y reemplazar la copia guardada?',

--- a/src/i18n/translations/appSettings1.ts
+++ b/src/i18n/translations/appSettings1.ts
@@ -36,7 +36,8 @@ export const appSettings1 = {
       'The AI bot name must be at least 3 characters long',
     'appSettings.toast.linkReindexed': 'Link {url} successfully reindexed',
     'appSettings.toast.reindexFailed': 'Failed to reindex site crawl',
-    'appSettings.toast.siteCrawlSet': 'Site crawl set successfully',
+    'appSettings.toast.siteCrawlSet':
+      'Crawl started. Indexed pages appear in the list once it finishes - reopen this tab in a minute.',
     'appSettings.toast.siteCrawlFailed': 'Failed to set site crawl',
     'appSettings.confirmRecrawlIndexed':
       '{url} is already indexed. Crawl it again and replace the stored copy?',
@@ -235,7 +236,7 @@ export const appSettings1 = {
     'appSettings.toast.reindexFailed':
       'Échec de la réindexation du site',
     'appSettings.toast.siteCrawlSet':
-      "Exploration du site configurée avec succès",
+      "Exploration lancée. Les pages indexées apparaîtront dans la liste une fois terminée - rouvrez cet onglet dans une minute.",
     'appSettings.toast.siteCrawlFailed':
       "Échec de la configuration de l'exploration du site",
     'appSettings.confirmRecrawlIndexed':
@@ -458,7 +459,7 @@ export const appSettings1 = {
     'appSettings.toast.reindexFailed':
       'No se pudo reindexar el rastreo del sitio',
     'appSettings.toast.siteCrawlSet':
-      'Rastreo del sitio configurado correctamente',
+      'Rastreo iniciado. Las páginas indexadas aparecerán en la lista cuando termine: vuelve a abrir esta pestaña en un minuto.',
     'appSettings.toast.siteCrawlFailed':
       'No se pudo configurar el rastreo del sitio',
     'appSettings.confirmRecrawlIndexed':

--- a/src/pages/AppSettings/AppSettings.tsx
+++ b/src/pages/AppSettings/AppSettings.tsx
@@ -511,10 +511,14 @@ export default function AppSettings() {
 
     const crawlOnce = async (force: boolean) => {
       const response = await setSourcesSiteCrawl(appId, url, followLink, force);
+      // resultV2 is empty now that the crawler queues the job and answers before
+      // fetching anything - the pages arrive later via its callback. Kept as a
+      // merge rather than dropped so the reindex path (which does still answer
+      // with rows) and any future synchronous response keep working.
       setAiBot((prev) => {
         const combined = [
           ...prev.siteUrlsV2,
-          ...(response.data.resultV2 as SiteLinks[]),
+          ...((response.data.resultV2 ?? []) as SiteLinks[]),
         ];
         const uniqueById: SiteLinks[] = Array.from(
           new Map(combined.map((item) => [item.id, item])).values()

--- a/src/pages/WpSetup/index.tsx
+++ b/src/pages/WpSetup/index.tsx
@@ -148,13 +148,17 @@ export default function WpSetup() {
       }
 
       if (newAgentId && crawlUrl.trim()) {
+        // Always "still running": the crawler queues the job and answers
+        // immediately, so a successful POST means indexing has *started*, not
+        // that any page is stored yet. A failure lands in the same state from
+        // the user's point of view - app and bot are usable either way, the RAG
+        // content just keeps filling in behind them.
+        setCrawlIncomplete(true);
         try {
           await httpAgentSiteCrawl(newAppId, newAgentId, crawlUrl.trim(), true);
         } catch (_) {
-          // Treat any crawl failure (incl. client-side timeout before backend
-          // finishes) as "still running." App and bot are already usable; the
-          // RAG content just keeps filling in.
-          setCrawlIncomplete(true);
+          // Non-fatal: setup completes, the assistant just starts without
+          // site knowledge.
         }
       }
 


### PR DESCRIPTION
## What

Site-crawl UI now says indexing has *started* and the pages arrive later, instead of reporting success as if the work were done.

## Why

Pairs with dappros/ethora-backend#118, which makes the crawler queue the job and answer before fetching anything. A site-crawl POST now comes back with no pages. All three call sites read as if the crawl had completed by the time the request resolved:

- **Agent → Web Index** ([AgentPanels.tsx](src/components/Agents/panels/AgentPanels.tsx)) — toasted "Crawl queued" and then immediately reloaded the list, which cannot contain the new rows yet. Read as "crawled, found nothing".
- **App Settings → AI Widget** ([AppSettings.tsx](src/pages/AppSettings/AppSettings.tsx)) — "Site crawl set successfully", merging a `resultV2` that is now always empty.
- **WordPress setup** ([WpSetup/index.tsx](src/pages/WpSetup/index.tsx)) — worst of the three: the "indexing is still finishing in the background" note was only rendered when the request **failed**. On the success path the user was told the assistant was ready with no hint that indexing was still running.

## How

- Toast strings in all three languages (en/fr/es) now state that indexed pages appear once the crawl finishes, and when to look again.
- WP setup sets `crawlIncomplete` whenever a crawl was requested at all, not just on error. The existing `wpSetup.crawlIncompleteText` copy already said the right thing, so it is unchanged.
- The Web Index list reload after a crawl is kept — it will not show the new rows yet, but it resets paging to where they will appear (rows sort newest-first) and reflects true server state rather than an optimistic guess.
- `resultV2` is still merged in App Settings, defaulting to `[]` rather than assuming the field is present: the reindex path shares that state and does still answer with rows.

## What this does not do

There is no auto-refresh. The operator still has to reload the list manually, which is why the copy explicitly asks them to come back in a minute rather than implying rows will appear on their own. Live progress needs per-page streaming from the crawler plus a realtime channel to the browser — a separate piece of work.

Also noting for later: `wpSetup.provisioningText` ("Indexing your site - usually under a minute") now shows during a step that completes in seconds. Left alone here since it is not false about indexing itself, but it deserves a rethink.

## Test

- `npm run typecheck` clean.
- `npx eslint` on the changed files reports the same 5 pre-existing errors as the base branch (`catch (_)` and `any` in WpSetup) — no new findings.
- Not yet clicked through against a stack running the companion backend branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)