### PR TITLE
feat(agents): show a crawl filling the Web Index while it runs

### DIFF
--- a/src/components/Agents/panels/AgentPanels.tsx
+++ b/src/components/Agents/panels/AgentPanels.tsx
@@ -30,8 +30,10 @@ import {
   httpListSiteSourcesV2,
   httpPostFile,
   httpReindexSiteSourceV2,
+  httpGetSiteCrawlJob,
   httpTestMessageAgentBotInstance,
 } from '../../../http';
+import { useSiteCrawlEvents, SiteCrawlEvent } from '../../../hooks/useSiteCrawlEvents';
 import { useTranslation } from '../../../i18n/useTranslation';
 import { ModelAgent, ModelAppDefaulRooom, ModelBotInstance } from '../../../models';
 import { agentPromptTemplates } from '../../../constants/agentPromptTemplates';
@@ -273,6 +275,23 @@ type SiteSourceRow = {
 // panel scrollable without pagination controls dominating a small index.
 const SITE_SOURCES_PAGE_SIZE = 25;
 
+// A crawl delivers pages in batches, so progress events arrive in bursts. Refetching
+// the list on every one of them would hammer the endpoint for no visible gain -
+// collapse a burst into one reload.
+const LIVE_RELOAD_DEBOUNCE_MS = 1200;
+
+// Fallback poll for jobs we are showing as running. Centrifugo delivery is
+// unacknowledged: if the terminal event is missed (tab was reloading, socket was
+// reconnecting) the progress line would otherwise sit there forever.
+const JOB_RECONCILE_MS = 15000;
+
+// A crawl or reindex this panel is currently watching.
+interface LiveCrawlJob {
+  url: string;
+  kind: 'crawl' | 'reindex';
+  savedPages: number;
+}
+
 // The API's error shape, narrowed once. Toasts across this file otherwise reach
 // into `e.response.data.error` through an `any`.
 function apiErrorMessage(e: unknown): string {
@@ -333,6 +352,10 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
   const [selected, setSelected] = useState<Set<string>>(new Set());
   // Row whose stored markdown is open in the viewer, if any.
   const [viewing, setViewing] = useState<SiteSourceRow | null>(null);
+  // Crawls/reindexes still running, keyed by jobId. Populated when this panel
+  // starts one, and by events - which also arrive for a job started in another
+  // tab, since the backend publishes to the user's personal channel.
+  const [liveJobs, setLiveJobs] = useState<Record<string, LiveCrawlJob>>({});
 
   // If the parent's scope wasn't usable (e.g. agent has no originAppId), fall back to
   // the user's first owned app so the UI is functional out of the box.
@@ -372,12 +395,136 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
     }
   };
   // Switching app scope invalidates the current page position, and a selection
-  // of ids from the previous app must not survive into the new one.
+  // of ids from the previous app must not survive into the new one. Live jobs go
+  // too: they belong to the app that was scoped when they started.
   useEffect(() => {
     setSelected(new Set());
+    setLiveJobs({});
     loadList(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appId]);
+
+  // Live progress ------------------------------------------------------------
+  //
+  // Pages are stored in batches while a crawl runs, so the list genuinely
+  // changes under the operator. Refetch on the events rather than polling, and
+  // keep the reload debounced - a burst of chunk events is one visible change.
+  const reloadTimer = useRef<number | null>(null);
+  // Refreshed on every render so the debounced reload always uses the page the
+  // operator is looking at now, not the one that was current when it was queued.
+  const reloadCurrentPage = useRef(() => {});
+  reloadCurrentPage.current = () => { void loadList(offset); };
+
+  const scheduleReload = () => {
+    if (reloadTimer.current !== null) return;
+    reloadTimer.current = window.setTimeout(() => {
+      reloadTimer.current = null;
+      reloadCurrentPage.current();
+    }, LIVE_RELOAD_DEBOUNCE_MS);
+  };
+
+  useEffect(() => () => {
+    if (reloadTimer.current !== null) window.clearTimeout(reloadTimer.current);
+  }, []);
+
+  const forgetJob = (jobId: string) =>
+    setLiveJobs((prev) => {
+      if (!prev[jobId]) return prev;
+      const next = { ...prev };
+      delete next[jobId];
+      return next;
+    });
+
+  // Shared by the event path and the reconcile poll, so a job that finishes
+  // while the socket is down is reported exactly the same way.
+  const finishJob = (
+    jobId: string,
+    outcome: { kind: 'crawl' | 'reindex'; url: string; savedPages: number; failed: boolean; error?: string | null; truncated?: boolean; truncatedReason?: string | null }
+  ) => {
+    forgetJob(jobId);
+    if (outcome.failed) {
+      toast.error(
+        t(outcome.kind === 'reindex' ? 'agentPanels.reindexFailedEvent' : 'agentPanels.crawlFailedEvent')
+          .replace('{url}', outcome.url)
+          .replace('{error}', outcome.error || '')
+      );
+    } else {
+      toast.success(
+        outcome.kind === 'reindex'
+          ? t('agentPanels.reindexDone').replace('{url}', outcome.url)
+          : t('agentPanels.crawlDone')
+              .replace('{n}', String(outcome.savedPages))
+              .replace('{url}', outcome.url)
+      );
+      if (outcome.truncated) {
+        toast.warning(t('agentPanels.crawlTruncated').replace('{reason}', outcome.truncatedReason || ''));
+      }
+    }
+    scheduleReload();
+  };
+
+  useSiteCrawlEvents({
+    appId,
+    onEvent: (ev: SiteCrawlEvent) => {
+      if (ev.type === 'site_crawl_progress') {
+        setLiveJobs((prev) => ({
+          ...prev,
+          [ev.jobId]: { url: ev.url, kind: ev.kind, savedPages: ev.savedPages },
+        }));
+        scheduleReload();
+        return;
+      }
+      finishJob(ev.jobId, {
+        kind: ev.kind,
+        url: ev.url,
+        savedPages: ev.savedPages,
+        failed: ev.type === 'site_crawl_failed',
+        error: ev.error,
+        truncated: ev.truncated,
+        truncatedReason: ev.truncatedReason,
+      });
+    },
+  });
+
+  // The safety net behind those events. Only runs while something is being
+  // watched, and only reads job rows - the authoritative copy of the state the
+  // events describe.
+  const liveJobIds = Object.keys(liveJobs);
+  useEffect(() => {
+    if (!appId || liveJobIds.length === 0) return;
+    const timer = window.setInterval(async () => {
+      for (const jobId of Object.keys(liveJobs)) {
+        try {
+          const r = await httpGetSiteCrawlJob(appId, jobId);
+          const job = r.data?.result;
+          if (!job) continue;
+          if (job.status === 'completed' || job.status === 'failed') {
+            finishJob(jobId, {
+              kind: job.kind === 'reindex' ? 'reindex' : 'crawl',
+              url: job.url,
+              savedPages: Number(job.savedPages) || 0,
+              failed: job.status === 'failed',
+              error: job.error,
+              truncated: Boolean(job.truncated),
+              truncatedReason: job.truncatedReason,
+            });
+          } else if (Number(job.savedPages) > (liveJobs[jobId]?.savedPages || 0)) {
+            // Progress events can be missed too, not just the terminal one.
+            setLiveJobs((prev) => (prev[jobId]
+              ? { ...prev, [jobId]: { ...prev[jobId], savedPages: Number(job.savedPages) || 0 } }
+              : prev));
+            scheduleReload();
+          }
+        } catch {
+          // A job row that 404s (purged, or belongs to another app) is not worth
+          // reporting - stop watching it.
+          forgetJob(jobId);
+        }
+      }
+    }, JOB_RECONCILE_MS);
+    return () => window.clearInterval(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appId, liveJobIds.join(',')]);
 
   // Deleting rows can empty the current page (or every page after it), which would
   // otherwise strand the user on a blank view. Clamp to the last offset that still
@@ -432,13 +579,19 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
   };
 
   const crawlOnce = async (force: boolean) => {
-    await httpAgentSiteCrawl(appId, agent.id, url, followLink, force);
+    const r = await httpAgentSiteCrawl(appId, agent.id, url, followLink, force);
     toast.success(t('agentPanels.crawlQueued'));
+    // Watch it from the moment it is queued rather than waiting for the first
+    // event, so a crawl that is still sitting in the crawler's queue is visible
+    // as something in flight instead of nothing at all.
+    const jobId = r.data?.jobId;
+    if (jobId) {
+      setLiveJobs((prev) => ({ ...prev, [jobId]: { url: r.data?.url || url, kind: 'crawl', savedPages: 0 } }));
+    }
     setUrl('');
-    // The crawler answers as soon as the job is queued, so this reload will not
-    // show the new rows yet - they land once the crawl finishes and calls back.
-    // Still worth doing: it resets paging to where those rows will appear (new
-    // rows sort newest-first) and the toast tells the operator to come back.
+    // Nothing has been fetched yet, so this reload shows no new rows. Still worth
+    // doing: it resets paging to where the rows will appear as they land, since
+    // the list sorts newest-first.
     await loadList(0);
   };
 
@@ -502,6 +655,27 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
           {busy ? t('agentPanels.crawling') : t('agentPanels.crawl')}
         </button>
       </div>
+
+      {/* One line per crawl in flight. Present only while something is running,
+          so the panel looks exactly as it did when nothing is. */}
+      {liveJobIds.length > 0 && (
+        <div className="space-y-1">
+          {liveJobIds.map((jobId) => {
+            const job = liveJobs[jobId];
+            return (
+              <div key={jobId} className="flex items-center gap-2 text-xs text-brand-600 bg-brand-50 border border-brand-100 rounded px-2 py-1">
+                <span className="inline-block h-2 w-2 rounded-full bg-brand-500 animate-pulse" aria-hidden />
+                <span className="font-mono break-all">{job.url}</span>
+                <span className="text-gray-500 whitespace-nowrap">
+                  {job.kind === 'reindex'
+                    ? t('agentPanels.reindexRunning')
+                    : t('agentPanels.crawlRunning').replace('{n}', String(job.savedPages))}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       <div className="flex items-center justify-between gap-2 text-xs text-gray-500 min-h-[28px]">
         <span>
@@ -592,8 +766,15 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
                     disabled={isDisabled || busy}
                     onClick={async () => {
                       try {
-                        await httpReindexSiteSourceV2(appId, row.id);
+                        const r = await httpReindexSiteSourceV2(appId, row.id);
                         toast.success(t('agentPanels.reindexQueued'));
+                        // Queued like a crawl - the refreshed copy lands on the
+                        // callback, and the row's size/updated columns only move
+                        // once it does.
+                        const jobId = r.data?.jobId;
+                        if (jobId) {
+                          setLiveJobs((prev) => ({ ...prev, [jobId]: { url: row.url, kind: 'reindex', savedPages: 0 } }));
+                        }
                         await loadList(offset);
                       } catch (e: any) {
                         toast.error(`${t('agentPanels.reindexFailedPrefix')} ${e?.response?.data?.error || e.message}`);

--- a/src/components/Agents/panels/AgentPanels.tsx
+++ b/src/components/Agents/panels/AgentPanels.tsx
@@ -275,9 +275,11 @@ type SiteSourceRow = {
 // panel scrollable without pagination controls dominating a small index.
 const SITE_SOURCES_PAGE_SIZE = 25;
 
-// A crawl delivers pages in batches, so progress events arrive in bursts. Refetching
-// the list on every one of them would hammer the endpoint for no visible gain -
-// collapse a burst into one reload.
+// Progress events carry the rows they stored, so the table is updated from the
+// event itself and a running crawl needs no refetch at all. This debounce is
+// only for the cases where the event could not carry them: a delivery too large
+// for one payload (rowsTruncated), or a crawl finishing, where one quiet
+// reconcile is cheaper than trusting the merge to have been complete.
 const LIVE_RELOAD_DEBOUNCE_MS = 1200;
 
 // Fallback poll for jobs we are showing as running. Centrifugo delivery is
@@ -290,6 +292,16 @@ interface LiveCrawlJob {
   url: string;
   kind: 'crawl' | 'reindex';
   savedPages: number;
+}
+
+// Did a refetch actually bring anything new? Compares what the table renders -
+// a crawl only ever adds rows or rewrites a page's size, so id + size + the
+// update stamp is the whole visible surface.
+function sameSiteSourceRows(a: SiteSourceRow[], b: SiteSourceRow[]) {
+  if (a.length !== b.length) return false;
+  return a.every((row, i) =>
+    row.id === b[i].id && row.mdByteSize === b[i].mdByteSize && row.updatedAt === b[i].updatedAt
+  );
 }
 
 // The API's error shape, narrowed once. Toasts across this file otherwise reach
@@ -370,28 +382,39 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
 
   // Takes the offset explicitly: callers that move between pages or drop the last row
   // of a page need the fetch to use the new offset without waiting for a re-render.
-  const loadList = async (nextOffset = offset) => {
+  //
+  // `silent` is for the refetches nobody asked for - the ones a running crawl
+  // triggers as its pages land. Those must not look like the table reloading:
+  // no "Loading..." placeholder, no error toast, and the table is left alone if
+  // the server came back with what is already on screen.
+  const loadList = async (nextOffset = offset, opts: { silent?: boolean } = {}) => {
     if (!appId) {
       setRows([]);
       setTotal(0);
       return;
     }
-    setLoadingList(true);
+    if (!opts.silent) setLoadingList(true);
     try {
       const r = await httpListSiteSourcesV2(appId, { limit: SITE_SOURCES_PAGE_SIZE, offset: nextOffset });
       // Endpoint returns { result: SiteSourceRow[], pagination: { total, limit, offset, hasMore } } in v2.
       const items: SiteSourceRow[] = r.data?.result || r.data?.items || [];
-      setRows(items);
+      // Handing React a fresh array on every poll repaints every row, which is
+      // what a once-a-second background refetch would otherwise look like.
+      setRows((prev) => (sameSiteSourceRows(prev, items) ? prev : items));
       // Older backends have no pagination block; total then degrades to the page length,
       // which still renders a sane (if truncated) count rather than 0.
       setTotal(Number(r.data?.pagination?.total ?? items.length));
       setOffset(nextOffset);
     } catch (e: any) {
+      // A background refetch that fails changes nothing on screen. The operator
+      // did not ask for it, and blanking a list they are reading (or toasting
+      // once a second for a blip) is worse than showing slightly stale rows.
+      if (opts.silent) return;
       toast.error(`${t('agentPanels.failedToLoadUrlsPrefix')} ${e?.response?.data?.error || e.message}`);
       setRows([]);
       setTotal(0);
     } finally {
-      setLoadingList(false);
+      if (!opts.silent) setLoadingList(false);
     }
   };
   // Switching app scope invalidates the current page position, and a selection
@@ -406,14 +429,17 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
 
   // Live progress ------------------------------------------------------------
   //
-  // Pages are stored in batches while a crawl runs, so the list genuinely
-  // changes under the operator. Refetch on the events rather than polling, and
-  // keep the reload debounced - a burst of chunk events is one visible change.
+  // Pages are stored in batches while a crawl runs, and each event carries the
+  // rows that landed - so the table is updated from the event itself. No poll,
+  // no refetch, and no "Loading..." replacing a list the operator is reading.
   const reloadTimer = useRef<number | null>(null);
   // Refreshed on every render so the debounced reload always uses the page the
   // operator is looking at now, not the one that was current when it was queued.
   const reloadCurrentPage = useRef(() => {});
-  reloadCurrentPage.current = () => { void loadList(offset); };
+  reloadCurrentPage.current = () => { void loadList(offset, { silent: true }); };
+  // When an event last arrived. While they are flowing there is nothing for the
+  // reconcile poll to catch up on, so it stays out of the way.
+  const lastEventAt = useRef(0);
 
   const scheduleReload = () => {
     if (reloadTimer.current !== null) return;
@@ -427,6 +453,39 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
     if (reloadTimer.current !== null) window.clearTimeout(reloadTimer.current);
   }, []);
 
+  // Ids the table already holds. Kept alongside `rows` rather than derived from
+  // it inside the merge: two events can land before React has re-rendered, and
+  // a stale closure would count the same row as new twice.
+  const knownRowIds = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    knownRowIds.current = new Set(rows.map((row) => row.id));
+  }, [rows]);
+
+  // Put the rows an event delivered into the table.
+  //
+  // The list is newest-first, so fresh rows belong at the top of page 0. On any
+  // other page they belong to a page the operator is not looking at, and only
+  // the count changes. A row that is already on screen was re-crawled: its size
+  // and timestamp are replaced in place, which is what a reindex looks like.
+  const mergeEventRows = (incoming: SiteSourceRow[]) => {
+    if (!incoming?.length) return;
+    const fresh = incoming.filter((row) => row.id && !knownRowIds.current.has(row.id));
+    const updates = new Map(incoming.filter((row) => knownRowIds.current.has(row.id)).map((row) => [row.id, row]));
+    fresh.forEach((row) => knownRowIds.current.add(row.id));
+
+    if (updates.size > 0) {
+      setRows((prev) => prev.map((row) => (updates.has(row.id) ? { ...row, ...updates.get(row.id)! } : row)));
+    }
+    if (fresh.length > 0) {
+      setTotal((prev) => prev + fresh.length);
+      // Only page 0 shows the newest rows. Trimming to the page size keeps the
+      // table the size it would be after a refetch, so paging stays consistent.
+      if (offset === 0) {
+        setRows((prev) => [...fresh, ...prev].slice(0, SITE_SOURCES_PAGE_SIZE));
+      }
+    }
+  };
+
   const forgetJob = (jobId: string) =>
     setLiveJobs((prev) => {
       if (!prev[jobId]) return prev;
@@ -439,7 +498,7 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
   // while the socket is down is reported exactly the same way.
   const finishJob = (
     jobId: string,
-    outcome: { kind: 'crawl' | 'reindex'; url: string; savedPages: number; failed: boolean; error?: string | null; truncated?: boolean; truncatedReason?: string | null }
+    outcome: { kind: 'crawl' | 'reindex'; url: string; savedPages: number; failed: boolean; error?: string | null; truncated?: boolean; truncatedReason?: string | null; reconcile?: boolean }
   ) => {
     forgetJob(jobId);
     if (outcome.failed) {
@@ -460,18 +519,29 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
         toast.warning(t('agentPanels.crawlTruncated').replace('{reason}', outcome.truncatedReason || ''));
       }
     }
-    scheduleReload();
+    // Reconcile once at the end. The rows are already on screen, merged from the
+    // events, so this is silent and normally a no-op - it exists to correct the
+    // count and pick up anything an event could not carry (or that arrived while
+    // the socket was down and the poll below found instead).
+    if (outcome.reconcile !== false) scheduleReload();
   };
 
   useSiteCrawlEvents({
     appId,
     onEvent: (ev: SiteCrawlEvent) => {
+      lastEventAt.current = Date.now();
+      // The rows the event brought go straight into the table - this is what
+      // replaces refetching the list while a crawl runs.
+      mergeEventRows(ev.rows || []);
+      // ...unless there were more than one payload can carry, in which case the
+      // table is now missing rows and only a fetch can fill them in.
+      if (ev.rowsTruncated) scheduleReload();
+
       if (ev.type === 'site_crawl_progress') {
         setLiveJobs((prev) => ({
           ...prev,
           [ev.jobId]: { url: ev.url, kind: ev.kind, savedPages: ev.savedPages },
         }));
-        scheduleReload();
         return;
       }
       finishJob(ev.jobId, {
@@ -493,6 +563,10 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
   useEffect(() => {
     if (!appId || liveJobIds.length === 0) return;
     const timer = window.setInterval(async () => {
+      // Events are arriving, so the panel is already up to date - polling on top
+      // of them is pure noise. This only earns its keep when the socket has gone
+      // quiet and a terminal event may have been missed.
+      if (Date.now() - lastEventAt.current < JOB_RECONCILE_MS) return;
       for (const jobId of Object.keys(liveJobs)) {
         try {
           const r = await httpGetSiteCrawlJob(appId, jobId);
@@ -591,8 +665,9 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
     setUrl('');
     // Nothing has been fetched yet, so this reload shows no new rows. Still worth
     // doing: it resets paging to where the rows will appear as they land, since
-    // the list sorts newest-first.
-    await loadList(0);
+    // the list sorts newest-first. Silent for the same reason - there is nothing
+    // to announce, and the crawl's own progress line is already on screen.
+    await loadList(0, { silent: true });
   };
 
   const handleCrawl = async () => {

--- a/src/hooks/useCentrifuge.ts
+++ b/src/hooks/useCentrifuge.ts
@@ -11,24 +11,20 @@ let lastWsTokenRefresh = 0;
 const VITE_APP_CENTRIFUGE_SERVICE = import.meta.env.VITE_APP_CENTRIFUGE_SERVICE || 
   (import.meta.env.DEV ? 'ws://localhost:8001/connection/websocket' : undefined);
 
-type CounterType =
-  | 'counter_chats'
-  | 'counter_api_calls'
-  | 'counter_aitokens'
-  | 'counter_files'
-  | 'counter_transactions'
-  | 'counter_sessions'
-  | 'counter_registered';
-
-  interface CentrifugeData {
-    type: CounterType;
-    appId: string;
-  }
+// The personal channel carries more than the stat counters it started with -
+// site-crawl progress rides on it too - so the payload is typed as the envelope
+// every publication shares. Consumers discriminate on `type` and narrow to
+// their own shape (see useCentrifugeAppUpdater, useSiteCrawlEvents).
+export interface CentrifugePayload {
+  type: string;
+  appId: string;
+  [key: string]: unknown;
+}
 
 export function useCentrifugeChannel() {
    const currentUser = useAppStore((s) => s.currentUser);
 
-  const [data, setData] = useState<CentrifugeData>();
+  const [data, setData] = useState<CentrifugePayload>();
   const [connected, setConnected] = useState(false);
 
   const getToken = async () => {

--- a/src/hooks/useSiteCrawlEvents.ts
+++ b/src/hooks/useSiteCrawlEvents.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import { useCentrifugeChannel } from './useCentrifuge';
+
+// Live crawl/reindex events, published by the backend to the actor who started
+// the job (see services/centrifugo.publishToUser on the API side).
+//
+// A crawl is asynchronous: the POST answers as soon as the job is queued, and
+// pages are stored in batches as the crawler finds them. These events are what
+// turn that into something visible - without them the only way to see a crawl
+// progress is to keep pressing reload.
+//
+// Treat every event as "something changed, refetch", never as the data itself:
+// a Centrifugo publish is unacknowledged and unreplayable, so a client that was
+// reloading or briefly offline misses it silently. The authoritative state is
+// the Web Index list plus GET /v2/apps/{appId}/sources/site-crawl-jobs/{jobId}.
+export type SiteCrawlEventType =
+  | 'site_crawl_progress'
+  | 'site_crawl_completed'
+  | 'site_crawl_failed';
+
+export interface SiteCrawlEvent {
+  type: SiteCrawlEventType;
+  appId: string;
+  jobId: string;
+  // 'crawl' for a new URL, 'reindex' for refreshing a row already indexed.
+  kind: 'crawl' | 'reindex';
+  url: string;
+  status: string;
+  // Whole-job totals, not this batch: what to render in a progress line.
+  savedPages: number;
+  totalBytes: number;
+  truncated: boolean;
+  truncatedReason: string | null;
+  error?: string | null;
+}
+
+function isSiteCrawlEvent(data: unknown): data is SiteCrawlEvent {
+  const type = (data as { type?: unknown })?.type;
+  return typeof type === 'string' && type.startsWith('site_crawl_');
+}
+
+interface Options {
+  // Events for other apps are dropped. Omit to accept every app's events.
+  appId?: string;
+  onEvent: (event: SiteCrawlEvent) => void;
+}
+
+export function useSiteCrawlEvents({ appId, onEvent }: Options) {
+  const { data, connected } = useCentrifugeChannel();
+  // Kept in a ref so a caller can pass an inline arrow function without every
+  // render re-running the effect and replaying the last event it still holds.
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+  // useCentrifugeChannel exposes only the most recent publication, so the same
+  // object stays in `data` until the next one arrives. Without this guard a
+  // re-render for any other reason would deliver it a second time.
+  const lastSeen = useRef<unknown>(null);
+
+  useEffect(() => {
+    if (!data || data === lastSeen.current) return;
+    lastSeen.current = data;
+    if (!isSiteCrawlEvent(data)) return;
+    if (appId && data.appId !== appId) return;
+    onEventRef.current(data);
+  }, [data, appId]);
+
+  return { connected };
+}

--- a/src/hooks/useSiteCrawlEvents.ts
+++ b/src/hooks/useSiteCrawlEvents.ts
@@ -9,14 +9,30 @@ import { useCentrifugeChannel } from './useCentrifuge';
 // turn that into something visible - without them the only way to see a crawl
 // progress is to keep pressing reload.
 //
-// Treat every event as "something changed, refetch", never as the data itself:
-// a Centrifugo publish is unacknowledged and unreplayable, so a client that was
-// reloading or briefly offline misses it silently. The authoritative state is
-// the Web Index list plus GET /v2/apps/{appId}/sources/site-crawl-jobs/{jobId}.
+// Events carry the rows they stored, so a subscriber can render a crawl as it
+// happens without polling or refetching. They are still not the system of
+// record: a Centrifugo publish is unacknowledged and unreplayable, so a client
+// that was reloading or briefly offline misses one silently. Merge what arrives,
+// and reconcile against the Web Index list plus
+// GET /v2/apps/{appId}/sources/site-crawl-jobs/{jobId} - never assume the stream
+// was complete.
 export type SiteCrawlEventType =
   | 'site_crawl_progress'
   | 'site_crawl_completed'
   | 'site_crawl_failed';
+
+// One Web Index row as the event carries it - the same shape the list endpoint
+// returns, minus the markdown. This is what lets a subscriber update its table
+// from the event instead of re-reading the list every time a batch lands.
+export interface SiteCrawlEventRow {
+  id: string;
+  url: string;
+  originUrl?: string;
+  mdByteSize?: number;
+  tags?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
 
 export interface SiteCrawlEvent {
   type: SiteCrawlEventType;
@@ -26,6 +42,11 @@ export interface SiteCrawlEvent {
   kind: 'crawl' | 'reindex';
   url: string;
   status: string;
+  // Rows stored by the batch this event reports.
+  rows?: SiteCrawlEventRow[];
+  // More rows landed than the payload carries: the receiver's copy of the list
+  // is incomplete and has to be re-read.
+  rowsTruncated?: boolean;
   // Whole-job totals, not this batch: what to render in a progress line.
   savedPages: number;
   totalBytes: number;

--- a/src/http.ts
+++ b/src/http.ts
@@ -857,8 +857,22 @@ export function httpDeleteSiteSourceV2Url(appId: string, siteSourceIds: string |
   return httpV2.delete(`/apps/${appId}/sources/site-crawl-v2/url`, { data: { ids } });
 }
 
+// Queues a re-crawl of one already-indexed row. Answers { status: 'queued', jobId }
+// the same way a fresh crawl does - the stored copy is overwritten later, when the
+// crawler calls back, so the row's size and updatedAt only move then.
 export function httpReindexSiteSourceV2(appId: string, urlId: string) {
   return httpV2.post(`/apps/${appId}/sources/site-crawl-reindex`, { urlId });
+}
+
+// Status of a queued crawl or reindex: { status, kind, url, savedPages, totalBytes,
+// truncated, error, startedAt, finishedAt }.
+//
+// The live view of a crawl comes from Centrifugo events (useSiteCrawlEvents), but
+// those are unacknowledged and unreplayable - a client that reloaded or briefly
+// lost the socket never learns the crawl ended. This is the reconcilable copy of
+// the same state; poll it for any job the UI still believes is running.
+export function httpGetSiteCrawlJob(appId: string, jobId: string) {
+  return httpV2.get(`/apps/${appId}/sources/site-crawl-jobs/${jobId}`);
 }
 
 export function httpGetBotInstance(id: string) {

--- a/src/i18n/translations/aiWidget.ts
+++ b/src/i18n/translations/aiWidget.ts
@@ -209,7 +209,15 @@ export const aiWidget = {
     'agentPanels.crawling': 'Crawling...',
     'agentPanels.crawl': 'Crawl',
     'agentPanels.crawlQueued':
-      'Crawl started. Indexed pages appear here once it finishes - reload the list in a minute.',
+      'Crawl started. Pages appear in the list below as they are indexed.',
+    'agentPanels.crawlRunning': 'crawling - {n} pages indexed',
+    'agentPanels.reindexRunning': 'reindexing...',
+    'agentPanels.crawlDone': 'Crawl finished: {n} pages indexed from {url}',
+    'agentPanels.reindexDone': 'Reindex finished: {url}',
+    'agentPanels.crawlFailedEvent': 'Crawl failed for {url}: {error}',
+    'agentPanels.reindexFailedEvent': 'Reindex failed for {url}: {error}',
+    'agentPanels.crawlTruncated':
+      'Crawl limit reached ({reason}) - some pages were not indexed.',
     'agentPanels.crawlFailedPrefix': 'Crawl failed:',
     'agentPanels.confirmRecrawlIndexed':
       '{url} is already indexed. Crawl it again and replace the stored copy?',
@@ -539,7 +547,15 @@ export const aiWidget = {
     'agentPanels.crawling': 'Exploration en cours...',
     'agentPanels.crawl': 'Explorer',
     'agentPanels.crawlQueued':
-      "Exploration lancée. Les pages indexées apparaîtront ici une fois terminée - rechargez la liste dans une minute.",
+      "Exploration lancée. Les pages apparaissent dans la liste ci-dessous au fur et à mesure de leur indexation.",
+    'agentPanels.crawlRunning': 'exploration - {n} pages indexées',
+    'agentPanels.reindexRunning': 'réindexation...',
+    'agentPanels.crawlDone': 'Exploration terminée : {n} pages indexées depuis {url}',
+    'agentPanels.reindexDone': 'Réindexation terminée : {url}',
+    'agentPanels.crawlFailedEvent': "Échec de l'exploration de {url} : {error}",
+    'agentPanels.reindexFailedEvent': 'Échec de la réindexation de {url} : {error}',
+    'agentPanels.crawlTruncated':
+      "Limite d'exploration atteinte ({reason}) - certaines pages n'ont pas été indexées.",
     'agentPanels.crawlFailedPrefix': "Échec de l'exploration :",
     'agentPanels.confirmRecrawlIndexed':
       '{url} est déjà indexée. Explorer à nouveau et remplacer la copie enregistrée ?',
@@ -877,7 +893,15 @@ export const aiWidget = {
     'agentPanels.crawling': 'Rastreando...',
     'agentPanels.crawl': 'Rastrear',
     'agentPanels.crawlQueued':
-      'Rastreo iniciado. Las páginas indexadas aparecerán aquí cuando termine: recarga la lista en un minuto.',
+      'Rastreo iniciado. Las páginas aparecen en la lista de abajo a medida que se indexan.',
+    'agentPanels.crawlRunning': 'rastreando: {n} páginas indexadas',
+    'agentPanels.reindexRunning': 'reindexando...',
+    'agentPanels.crawlDone': 'Rastreo finalizado: {n} páginas indexadas de {url}',
+    'agentPanels.reindexDone': 'Reindexación finalizada: {url}',
+    'agentPanels.crawlFailedEvent': 'Error al rastrear {url}: {error}',
+    'agentPanels.reindexFailedEvent': 'Error al reindexar {url}: {error}',
+    'agentPanels.crawlTruncated':
+      'Se alcanzó el límite de rastreo ({reason}): algunas páginas no se indexaron.',
     'agentPanels.crawlFailedPrefix': 'Error al rastrear:',
     'agentPanels.confirmRecrawlIndexed':
       '{url} ya está indexada. ¿Rastrearla de nuevo y reemplazar la copia guardada?',


### PR DESCRIPTION
## What this is

The Web Index panel had no way to see a crawl happen. The POST answers as soon as the job is queued, so the toast told the operator to come back and reload in a minute, and a crawl that died said nothing at all.

The backend now stores pages in batches as the crawler finds them and publishes each batch — **including the rows it stored** — to the actor who started the job. This consumes that.

Backend counterpart: `dappros/ethora-backend#121`. Merge that first.

## Changes

- **`useSiteCrawlEvents`** — subscribes to `site_crawl_*` on the user's personal channel, filters by app, and guards against re-delivering the same publication (`useCentrifugeChannel` holds only the latest one, so any unrelated re-render would otherwise replay it).
- **The table updates from the events, not from a refetch.** New rows are prepended on page 0 (the list is newest-first, trimmed to the page size so paging stays consistent); a re-crawled page arrives under its existing id and is replaced in place, which is what a reindex looks like. A running crawl fetches nothing.
- **A line per running crawl** with its live page count, plus toasts for completion, failure and a hit crawl ceiling. Reindex is queued the same way now and gets the same treatment; `kind` on the event is what separates the two messages.
- **What is left of the reload is reconciliation, and it is silent**: no spinner, no error toast for a refetch nobody asked for, and the rows are left untouched when the response matches what is already rendered. It runs when an event says its payload was capped (`rowsTruncated`), once when a job ends, and from the poll below.
- **A poll of `GET /sources/site-crawl-jobs/{jobId}`** backs the events up for the one case they cannot cover: a terminal event that was never received. Runs only while something is being watched, and skips itself entirely while events are flowing.
- `useCentrifugeChannel`'s payload type is widened to the envelope every publication shares — the personal channel carries more than the stat counters it was built for. `useCentrifugeAppUpdater` already narrowed with its own cast and is unaffected.
- i18n: en / fr / es.

## Design note

Events are treated as "here is what changed", never as the system of record. A Centrifugo publish is unacknowledged and unreplayable, so a client that was reloading or briefly offline misses one silently — hence the reconcile paths above.

If the operator is not on the first page, new rows are deliberately **not** inserted: they belong to a page they are not looking at, and only the count moves. Pushing rows into the page someone is reading would shift it under them.

## Checks

`typecheck` clean. `build` clean. `lint` reports 235 problems — byte-for-byte identical to a clean `origin/2607`, i.e. nothing new.

Not covered by automated tests: the panel has no test harness in this repo. Behaviour was verified against a locally driven backend (real crawler container + real callback service + real Mongo) — event payloads carried the stored rows with real ids, sizes and URLs, and a reindex re-delivered its existing row id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
