### PR TITLE
fix(ai-widget): load built widget bundles as classic scripts

### DIFF
--- a/src/pages/AppSettings/AIWidget.tsx
+++ b/src/pages/AppSettings/AIWidget.tsx
@@ -93,7 +93,10 @@ function injectWidgetScript({
   // first bare import. Supporting it lets this preview run the widget's
   // current source with no build step, which is the only way to test an
   // unreleased widget without publishing a bundle first.
-  if (/\.[tj]sx?($|\?)/.test(widgetUrl)) {
+  // A built .js bundle must stay a classic script: module scripts are
+  // fetched in CORS mode, so a bundle served from a host without
+  // Access-Control-Allow-Origin would fail to load here.
+  if (/\.tsx?($|\?)/.test(widgetUrl)) {
     s.type = 'module';
   }
   s.src = widgetUrl;


### PR DESCRIPTION
## Problem

The **Test Widget** preview in App Settings set `type="module"` on the injected script for any entry matching `/\.[tj]sx?/` — i.e. `.ts`, `.tsx`, `.js` and `.jsx` alike.

Module scripts are fetched in CORS mode. A released widget bundle (`assistant<ver>.js`) served from a host that sends no `Access-Control-Allow-Origin` is therefore blocked by the browser before it ever runs, and TEST WIDGET fails with a CORS error.

## Fix

Narrow the check to `/\.tsx?/`, which is the case the branch was written for: the widget served straight from its own Vite dev server (`VITE_WIDGET_URL` pointing at `.../src/main.tsx`), where the entry really is an ES module with bare imports.

Built `.js` bundles now load as classic scripts, which need no CORS headers. The dev-server path is unchanged.

Comment added at the call site so the regex doesn't get "fixed" back.

## Verification

- `npx tsc -b --noEmit` clean.
- Behaviour is a single branch condition; no runtime code paths other than the `script.type` attribute are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)