### PR TITLE
Scope the Knowledge panel's lists to the agent

### DIFF
--- a/src/components/Agents/panels/AgentPanels.tsx
+++ b/src/components/Agents/panels/AgentPanels.tsx
@@ -395,7 +395,7 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
     }
     if (!opts.silent) setLoadingList(true);
     try {
-      const r = await httpListSiteSourcesV2(appId, { limit: SITE_SOURCES_PAGE_SIZE, offset: nextOffset });
+      const r = await httpListSiteSourcesV2(appId, { limit: SITE_SOURCES_PAGE_SIZE, offset: nextOffset, agentId: agent.id });
       // Endpoint returns { result: SiteSourceRow[], pagination: { total, limit, offset, hasMore } } in v2.
       const items: SiteSourceRow[] = r.data?.result || r.data?.items || [];
       // Handing React a fresh array on every poll repaints every row, which is
@@ -419,13 +419,16 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
   };
   // Switching app scope invalidates the current page position, and a selection
   // of ids from the previous app must not survive into the new one. Live jobs go
-  // too: they belong to the app that was scoped when they started.
+  // too: they belong to the app that was scoped when they started. The agent is
+  // in the deps for the same reason the app is: the list is scoped to (app,
+  // agent), so a parent that swaps the agent under a mounted panel would
+  // otherwise leave the previous agent's rows on screen.
   useEffect(() => {
     setSelected(new Set());
     setLiveJobs({});
     loadList(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appId]);
+  }, [appId, agent.id]);
 
   // Live progress ------------------------------------------------------------
   //
@@ -774,12 +777,9 @@ export const WebIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisab
         )}
       </div>
 
-      {/* Indexed URLs table - ported from the legacy AI Widget LinksTable. Shows every
-          row stored under the scoped app's siteSource collection. NB: the siteSource
-          model is keyed by appId only today, so for migrated apps this list may include
-          pages indexed by other agents that share the same app. We surface that as an
-          "(other agents)" hint when the row's url didn't originate from this agent's
-          recent crawls. */}
+      {/* Indexed URLs table - ported from the legacy AI Widget LinksTable. Shows the
+          rows this agent owns in the scoped app; siteSource carries an agentId, so
+          another agent's pages are not in this list even when they share the app. */}
       <div className="border rounded">
         <table className="w-full text-xs">
           <thead className="bg-gray-50">
@@ -961,7 +961,7 @@ export const DocsIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisa
     if (!appId) return;
     setLoadingList(true);
     try {
-      const resp = await httpListDocSourcesV2(appId);
+      const resp = await httpListDocSourcesV2(appId, agent.id);
       const result = resp?.data?.result;
       setRows(Array.isArray(result) ? result : []);
     } catch (e: any) {
@@ -977,7 +977,7 @@ export const DocsIndexPanel: React.FC<{ agent: ModelAgent; appId: string; isDisa
   useEffect(() => {
     if (appId) loadList();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appId]);
+  }, [appId, agent.id]);
 
   return (
     <div className="space-y-3 max-w-2xl">

--- a/src/http.ts
+++ b/src/http.ts
@@ -832,7 +832,10 @@ export function httpTestMessageAgentBotInstance(idOrAddress: string, botInstance
 // Used by the agent's Web Index tab to show the URL list (not just total bytes).
 // Pagination is opt-in server-side: without `limit` the backend returns every row,
 // which is what the legacy AI Widget LinksTable still relies on.
-export function httpListSiteSourcesV2(appId?: string, params?: { limit?: number; offset?: number }) {
+//
+// `agentId` narrows the list to one agent's rows. Omitting it lists the whole
+// app, which is what the legacy LinksTable wants — it has no agent to scope to.
+export function httpListSiteSourcesV2(appId?: string, params?: { limit?: number; offset?: number; agentId?: string }) {
   const config = params ? { params } : undefined;
   if (appId) return httpV2.get(`/apps/${appId}/sources/site-crawl`, config);
   return httpV2.get('/sources/site-crawl', config);
@@ -908,8 +911,10 @@ export function httpAgentDocsUpload(appId: string, agentId: string, files: File[
 // List uploaded doc sources for an App (ordered by createdAt, newest first
 // per the repo). Used by the Agents > Knowledge panel to confirm uploads
 // landed and to surface a delete affordance.
-export function httpListDocSourcesV2(appId: string) {
-  return httpV2.get(`/apps/${appId}/sources/docs`);
+// `agentId` narrows the list to one agent's uploads, the same way
+// httpListSiteSourcesV2 does for crawled pages.
+export function httpListDocSourcesV2(appId: string, agentId?: string) {
+  return httpV2.get(`/apps/${appId}/sources/docs`, agentId ? { params: { agentId } } : undefined);
 }
 
 export function httpDeleteDocSourceV2(appId: string, docId: string) {


### PR DESCRIPTION
Companion to dappros/ethora-backend#126, which adds `agentId` to `siteSource` / `documentSource`.

With rows now carrying an owner, the Web Index and Docs lists ask for the rows the open agent actually owns instead of everything under the scoped app. Without this a new agent in an already-indexed app still reads another agent's URLs.

- `httpListSiteSourcesV2` / `httpListDocSourcesV2` take an optional `agentId`. Omitting it keeps the whole-app listing the legacy AI Widget LinksTable depends on — it has no agent to scope to.
- `agent.id` joins `appId` in both load effects. The list is scoped to (app, agent), so a parent swapping the agent under a mounted panel would otherwise leave the previous agent's rows on screen.
- Drops the stale caveat above the URL table. The "(other agents)" hint it describes was never actually rendered, and the appId-only keying it warns about no longer exists.

`crawlOnce` already passed `agent.id`, so nothing changes on the request side.

## Testing

`npm run typecheck` clean. `npm run lint` on the two touched files reports the same 49 problems as on `2607` — no new lint findings (the repo-wide lint fails on both, pre-existing).

**Merge after the backend PR** — the `agentId` query param is ignored by a backend that does not have it yet, so the order is not load-bearing, but the panels only behave correctly once both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)